### PR TITLE
Bug fix(Reflect comment: https://github.com/egison/egison/pull/56#issuecomment-55673182)

### DIFF
--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -490,14 +490,11 @@ processMStates' stream@(MCons state _) =
 
 gatherBindings :: MatchingState -> Maybe [Binding]
 gatherBindings (MState _ _ bindings []) = return bindings
-gatherBindings (MState _ _ bindings trees) = (bindings ++) <$> gatherBindings' trees
-  where gatherBindings' :: [MatchingTree] -> Maybe [Binding]
-        gatherBindings' [] = return []
-        gatherBindings' (MAtom _ _ _ : _) = Nothing
-        gatherBindings' (MNode _ state : rest) = do
-          bs1 <- gatherBindings' rest
-          bs2 <- gatherBindings state
-          return $ bs2 ++ bs1
+gatherBindings (MState _ _ bindings trees) = isResolved trees >> return bindings
+  where isResolved :: [MatchingTree] -> Maybe ()
+        isResolved [] = return ()
+        isResolved (MAtom _ _ _ : _) = Nothing
+        isResolved (MNode _ state : rest) = gatherBindings state >> isResolved rest
 
 extractMatches :: [MList EgisonM MatchingState] -> EgisonM ([Match], [MList EgisonM MatchingState])
 extractMatches = extractMatches' ([], [])


### PR DESCRIPTION
Fix `Language.Egison.Core.gatherBindings` such that the following matching state results in returning only `bindings1`:

```
MState (...) (...) bindings1 [MNode (...) (MState (...) (...) bindings2 [])]
```

Now `gatherBindings` checks resolution of _whole_ matching states and return _the only top-level_ binding if resolved.

Thanks for your comment, @egisatoshi .
