### PR TITLE
Fix egison-mode.el to follow the Emacs Lisp conventions.

### DIFF
--- a/elisp/egison-mode.el
+++ b/elisp/egison-mode.el
@@ -80,44 +80,44 @@
   "Default expressions to highlight in Egison modes.")
 
 
-(defun open-paren-p ()
+(defun egison-open-paren-p ()
   (let ((c (string-to-char (thing-at-point 'char))))
     (or (eq c 40) (eq c 60) (eq c 91) (eq c 123))))
 
-(defun close-paren-p ()
+(defun egison-close-paren-p ()
   (let ((c (string-to-char (thing-at-point 'char))))
     (or (eq c 41) (eq c 62) (eq c 93) (eq c 125))))
 
-(defun last-unclosed-paren ()
+(defun egison-last-unclosed-paren ()
   (save-excursion
     (let ((pc 0))
       (while (<= pc 0)
         (if (bobp)
             (setq pc 2)
           (backward-char)
-          (if (open-paren-p)
+          (if (egison-open-paren-p)
               (progn
                 (setq pc (+ pc 1))
                 (if (and (= pc 0) (= (current-column) 0))
                     (setq pc 2)))
-            (if (close-paren-p)
+            (if (egison-close-paren-p)
                 (setq pc (- pc 1))))))
       (if (= pc 2)
           nil
         (point)))))
 
-(defun indent-point ()
+(defun egison-indent-point ()
   (save-excursion
     (beginning-of-line)
-    (let ((p (last-unclosed-paren)))
+    (let ((p (egison-last-unclosed-paren)))
       (if p
           (progn
-            (goto-char (last-unclosed-paren))
+            (goto-char (egison-last-unclosed-paren))
             (let ((cp (current-column)))
               (cond ((eq (string-to-char (thing-at-point 'char)) 40)
                      (forward-char)
                      (let* ((op (current-word))
-                            (ip (keyword-indent-point op)))
+                            (ip (egison-keyword-indent-point op)))
                        (if ip
                            (+ ip cp)
                          (progn (forward-sexp)
@@ -134,7 +134,7 @@
                     (t (+ 1 cp)))))
         0))))
 
-(defun keyword-indent-point (name)
+(defun egison-keyword-indent-point (name)
   (cond ((equal "module" name) 2)
         ((equal "define" name) 2)
         ((equal "test" name) 2)
@@ -174,7 +174,7 @@
 (defun egison-indent-line ()
   "indent current line as Egison code."
   (interactive)
-  (indent-line-to (indent-point)))
+  (indent-line-to (egison-indent-point)))
 
 
 (defvar egison-mode-map
@@ -197,7 +197,7 @@
   ;; (copy-syntax-table lisp-mode-syntax-table)
   "Syntax table for Egison mode")
 
-(defun egison-mode-variables ()
+(defun egison-mode-set-variables ()
   (set-syntax-table egison-mode-syntax-table)
   (set (make-local-variable 'font-lock-defaults)
        '((egison-font-lock-keywords
@@ -226,7 +226,7 @@ if that value is non-nil."
   (use-local-map egison-mode-map)
   (setq major-mode 'egison-mode)
   (setq mode-name "Egison")
-  (egison-mode-variables)
+  (egison-mode-set-variables)
   (run-mode-hooks 'egison-mode-hook))
 
 

--- a/elisp/egison-mode.el
+++ b/elisp/egison-mode.el
@@ -235,6 +235,7 @@
   (set (make-local-variable 'comment-start) ";")
   (set (make-local-variable 'comment-end) "")
   (set (make-local-variable 'comment-start-skip) ";+ *")
+  (set (make-local-variable 'comment-add) 1)
   (set (make-local-variable 'comment-end-skip) nil)
   )
 

--- a/elisp/egison-mode.el
+++ b/elisp/egison-mode.el
@@ -241,4 +241,6 @@ See `run-hooks'."
   :type 'hook
   :group 'egison)
 
+(provide 'egison-mode)
+
 ;;; egison-mode.el ends here

--- a/elisp/egison-mode.el
+++ b/elisp/egison-mode.el
@@ -212,6 +212,7 @@
   )
 
 
+;;;###autoload
 (defun egison-mode ()
   "Major mode for editing Egison code.
 

--- a/elisp/egison-mode.el
+++ b/elisp/egison-mode.el
@@ -1,12 +1,39 @@
 ;;; egison-mode.el --- Egison editing mode
 
-;; Copyright 2011-2013 Satoshi Egi
+;; Copyright (C) 2011-2015 Satoshi Egi
+
+;; Permission is hereby granted, free of charge, to any person obtaining
+;; a copy of this software and associated documentation files (the "Software"),
+;; to deal in the Software without restriction, including without limitation
+;; the rights to use, copy, modify, merge, publish, distribute, sublicense,
+;; and/or sell copies of the Software, and to permit persons to whom the Software
+;; is furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included
+;; in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+;; INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+;; A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+;; CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+;; OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ;;; Author: Satoshi Egi <egisatoshi@gmail.com>
 ;;; URL: https://github.com/egisatoshi/egison3/blob/master/elisp/egison-mode.el
 ;;; Version: 0.1.5
 
-;; Code goes here
+;;; Commentary:
+
+;; Emacs Mode for Egison
+;;
+;; Please put it in your load-path of Emacs. Then, add the following
+;; lines in your .emacs.
+;;
+;;   (autoload 'egison-mode "egison-mode" "Major mode for editing Egison code." t)
+;;   (setq auto-mode-alist (cons `("\\.egi$" . egison-mode) auto-mode-alist))
+
+;;; Code:
 
 (defconst egison-font-lock-keywords-1
   (eval-when-compile

--- a/elisp/egison-mode.el
+++ b/elisp/egison-mode.el
@@ -213,8 +213,8 @@
 
 (defvar egison-mode-syntax-table
   (let ((egison-mode-syntax-table (make-syntax-table)))
-    (modify-syntax-entry ?< "(" egison-mode-syntax-table)
-    (modify-syntax-entry ?> ")" egison-mode-syntax-table)
+    (modify-syntax-entry ?< "(>" egison-mode-syntax-table)
+    (modify-syntax-entry ?> ")<" egison-mode-syntax-table)
     (modify-syntax-entry ?\; "<" egison-mode-syntax-table)
     (modify-syntax-entry ?\n ">" egison-mode-syntax-table)
     (modify-syntax-entry ?\? "w" egison-mode-syntax-table)


### PR DESCRIPTION
I fixed `egison-mode.el` to follow the Emacs Lisp conventions (as suggested in the Emacs Lisp manual).
Please see and merge the commits if the changes seem reasonable.
Thanks.