### PR TITLE
improve error messages of binary operations for scalars

### DIFF
--- a/hs-src/Language/Egison/Primitives.hs
+++ b/hs-src/Language/Egison/Primitives.hs
@@ -317,6 +317,7 @@ scalarBinaryOp mOp = twoArgs $ \val val' -> do
   scalarBinaryOp' val val'
  where
   scalarBinaryOp' (ScalarData m1) (ScalarData m2) = (return . ScalarData . mathNormalize') (mOp m1 m2)
+  scalarBinaryOp' (ScalarData _)  val             = throwError $ TypeMismatch "number" (Value val)
   scalarBinaryOp' val             _               = throwError $ TypeMismatch "number" (Value val)
 
 plus :: PrimitiveFunc


### PR DESCRIPTION
So far the result of `(+ 3 "foo")` on Egison is as follow:
```
> (+ 3 "foo")
Expected number, but found: 3
```
This is because the left-hand side value is always regarded to as an unexpected value, on binary operations for two scalars.

My change improves the error message just like:
```
> (+ 3 "foo")
Expected number, but found: "foo"
```