### PR TITLE
Tighten base bounds, make it build with older GHCs

### DIFF
--- a/egison.cabal
+++ b/egison.cabal
@@ -101,7 +101,7 @@ Benchmark benchmark
 
 Executable egison
   Main-is:             egison.hs
-  Build-depends:       egison, base >= 4.0 && < 5, array, containers, unordered-containers, haskeline, transformers, mtl, parsec >= 3.0, directory, ghc, ghc-paths, filepath, text, regex-tdfa, process, vector, optparse-applicative
+  Build-depends:       egison, base >= 4.0 && < 5, array, containers, unordered-containers, haskeline, transformers, mtl, parsec >= 3.1, directory, ghc, ghc-paths, filepath, text, regex-tdfa, process, vector, optparse-applicative
   if !impl(ghc > 8.0)
     Build-Depends: semigroups
   Hs-Source-Dirs:      hs-src/Interpreter

--- a/egison.cabal
+++ b/egison.cabal
@@ -68,7 +68,7 @@ source-repository head
   location: https://github.com/egison/egison.git
 
 Library
-  Build-Depends:   base >= 4.0 && < 5, array, random, containers, unordered-containers, haskeline, transformers, mtl, parsec >= 3.0, directory, ghc, ghc-paths, text, regex-tdfa, process, vector, parallel, split, hashable
+  Build-Depends:   base >= 4.7 && < 5, array, random, containers, unordered-containers, haskeline, transformers, mtl >=2.2.1, parsec >= 3.0, directory, ghc, ghc-paths, text, regex-tdfa, process, vector, parallel, split, hashable
   if !impl(ghc > 8.0)
     Build-Depends: fail
   Hs-Source-Dirs:  hs-src
@@ -102,6 +102,8 @@ Benchmark benchmark
 Executable egison
   Main-is:             egison.hs
   Build-depends:       egison, base >= 4.0 && < 5, array, containers, unordered-containers, haskeline, transformers, mtl, parsec >= 3.0, directory, ghc, ghc-paths, filepath, text, regex-tdfa, process, vector, optparse-applicative
+  if !impl(ghc > 8.0)
+    Build-Depends: semigroups
   Hs-Source-Dirs:      hs-src/Interpreter
   Other-modules:       Paths_egison
   ghc-options:  -O3 -threaded -eventlog -rtsopts

--- a/hs-src/Interpreter/egison.hs
+++ b/hs-src/Interpreter/egison.hs
@@ -11,6 +11,7 @@ import           Prelude                    hiding (catch)
 
 import           Data.Char
 import           Data.List                  (intercalate)
+import           Data.Semigroup             ((<>))
 import qualified Data.Text                  as T
 
 import           Data.Version


### PR DESCRIPTION
Right now, egison only works with GHC >= 7.10.3; the `.cabal` file should reflect that. This PR also fixes builds for GHC 7.10.3-GHC 8.2.2