### PR TITLE
Display stack trace for TypeMismatch and ArgumentsNum*

### DIFF
--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -111,7 +111,7 @@ evalTopExpr' _ st (Execute expr) = do
   io <- evalStateT st [] >>= flip evalExpr expr
   case io of
     Value (IOFunc m) -> m >> return (Nothing, st)
-    _                -> throwError $ TypeMismatch "io" io
+    _                -> throwError =<< TypeMismatch "io" io <$> getFuncNameStack
 evalTopExpr' opts st (Load file) = do
   exprs <- if optSExpr opts then Parser.loadLibraryFile file else ParserNonS.loadLibraryFile file
   (bindings, _) <- collectDefs opts exprs [] []
@@ -132,13 +132,13 @@ evalExpr env (QuoteExpr expr) = do
   whnf <- evalExpr env expr
   case whnf of
     Value (ScalarData s) -> return . Value $ ScalarData $ Div (Plus [Term 1 [(Quote s, 1)]]) (Plus [Term 1 []])
-    _ -> throwError $ TypeMismatch "scalar in quote" whnf
+    _ -> throwError =<< TypeMismatch "scalar in quote" whnf <$> getFuncNameStack
 
 evalExpr env (QuoteSymbolExpr expr) = do
   whnf <- evalExpr env expr
   case whnf of
     Value val -> return . Value $ QuotedFunc val
-    _         -> throwError $ TypeMismatch "value in quote-function" whnf
+    _         -> throwError =<< TypeMismatch "value in quote-function" whnf <$> getFuncNameStack
 
 evalExpr env (VarExpr name) = do
   x <- refVar' env name >>= evalRef
@@ -235,8 +235,8 @@ evalExpr env (HashExpr assocs) = do
       ScalarData _ -> IntKey <$> fromEgison val
       Char c -> return (CharKey c)
       String str -> return (StrKey str)
-      _ -> throwError $ TypeMismatch "integer or string" $ Value val
-  makeHashKey whnf = throwError $ TypeMismatch "integer or string" whnf
+      _ -> throwError =<< TypeMismatch "integer or string" (Value val) <$> getFuncNameStack
+  makeHashKey whnf = throwError =<< TypeMismatch "integer or string" whnf <$> getFuncNameStack
 
 evalExpr env (IndexedExpr bool expr indices) = do
   tensor <- case expr of
@@ -499,7 +499,7 @@ evalExpr env (IoExpr expr) = do
       val <- m >>= evalWHNF
       case val of
         Tuple [_, val'] -> return $ Value val'
-    _ -> throwError $ TypeMismatch "io" io
+    _ -> throwError =<< TypeMismatch "io" io <$> getFuncNameStack
 
 evalExpr env (MatchAllExpr target matcher clauses) = do
   target <- evalExpr env target
@@ -651,7 +651,7 @@ evalExpr env (MemoizeExpr memoizeFrame expr) = do
                               retRef <- newEvaluatedObjectRef (Value ret)
                               liftIO $ writeIORef hashRef (HL.insert indices' retRef hash)
                               writeObjectRef ref (Value (MemoizedFunc name ref hashRef env' names body))
-                            _ -> throwError $ TypeMismatch "memoized-function" (Value x'))
+                            _ -> throwError =<< TypeMismatch "memoized-function" (Value x') <$> getFuncNameStack)
        memoizeFrame
   evalExpr env expr
 
@@ -898,7 +898,7 @@ applyFunc _ (Value (PrimitiveFunc _ func)) arg = func arg
 applyFunc _ (Value (IOFunc m)) arg =
   case arg of
      Value World -> m
-     _           -> throwError $ TypeMismatch "world" arg
+     _           -> throwError =<< TypeMismatch "world" arg <$> getFuncNameStack
 applyFunc _ (Value (QuotedFunc fn)) arg = do
   args <- tupleToList arg
   mExprs <- mapM extractScalar args
@@ -909,7 +909,7 @@ applyFunc _ (Value fn@(ScalarData (Div (Plus [Term 1 [(Symbol{}, 1)]]) (Plus [Te
                             ScalarData _ -> extractScalar arg
                             _ -> throwError $ EgisonBug "to use undefined functions, you have to use ScalarData args") args
   return (Value (ScalarData (Div (Plus [Term 1 [(Apply fn mExprs, 1)]]) (Plus [Term 1 []]))))
-applyFunc _ whnf _ = throwError $ TypeMismatch "function" whnf
+applyFunc _ whnf _ = throwError =<< TypeMismatch "function" whnf <$> getFuncNameStack
 
 refArray :: WHNFData -> [EgisonValue] -> EgisonM WHNFData
 refArray val [] = return val
@@ -925,7 +925,7 @@ refArray (Value (Array array)) (index:indices) =
              elms <- mapM (\arr -> refArray (Value arr) indices) (Array.elems array)
              elmRefs <- mapM newEvaluatedObjectRef elms
              return $ Intermediate $ IArray $ Array.listArray (1, size) elmRefs
-           _  -> throwError $ TypeMismatch "integer or symbol" (Value index)
+           _  -> throwError =<< TypeMismatch "integer or symbol" (Value index) <$> getFuncNameStack
 refArray (Intermediate (IArray array)) (index:indices) =
   if isInteger index
     then do i <- (fmap fromInteger . fromEgison) index
@@ -941,7 +941,7 @@ refArray (Intermediate (IArray array)) (index:indices) =
              elms <- mapM (`refArray` indices) arrs
              elmRefs <- mapM newEvaluatedObjectRef elms
              return $ Intermediate $ IArray $ Array.listArray (1, size) elmRefs
-           _  -> throwError $ TypeMismatch "integer or symbol" (Value index)
+           _  -> throwError =<< TypeMismatch "integer or symbol" (Value index) <$> getFuncNameStack
 refArray (Value (IntHash hash)) (index:indices) = do
   key <- fromEgison index
   case HL.lookup key hash of
@@ -972,7 +972,7 @@ refArray (Intermediate (IStrHash hash)) (index:indices) = do
   case HL.lookup key hash of
     Just ref -> evalRef ref >>= flip refArray indices
     Nothing  -> return $ Value Undefined
-refArray val _ = throwError $ TypeMismatch "array or hash" val
+refArray val _ = throwError =<< TypeMismatch "array or hash" val <$> getFuncNameStack
 
 arrayBounds :: WHNFData -> EgisonM WHNFData
 arrayBounds val = Value <$> arrayBounds' val
@@ -980,7 +980,7 @@ arrayBounds val = Value <$> arrayBounds' val
 arrayBounds' :: WHNFData -> EgisonM EgisonValue
 arrayBounds' (Intermediate (IArray arr)) = return $ Tuple [toEgison (fst (Array.bounds arr)), toEgison (snd (Array.bounds arr))]
 arrayBounds' (Value (Array arr))         = return $ Tuple [toEgison (fst (Array.bounds arr)), toEgison (snd (Array.bounds arr))]
-arrayBounds' val                         = throwError $ TypeMismatch "array" val
+arrayBounds' val                         = throwError =<< TypeMismatch "array" val <$> getFuncNameStack
 
 newThunk :: Env -> EgisonExpr -> Object
 newThunk env expr = Thunk $ evalExpr env expr
@@ -1185,7 +1185,7 @@ processMState' (MState env loops seqs bindings (MAtom pattern target matcher:tre
         Value (PatternFunc env'' names expr) ->
           let penv = zip names args
           in return $ msingleton $ MState env loops seqs bindings (MNode penv (MState env'' [] [] [] [MAtom expr target matcher]) : trees)
-        _ -> throwError $ TypeMismatch "pattern constructor" func'
+        _ -> throwError =<< TypeMismatch "pattern constructor" func' <$> getFuncNameStack
 
     DApplyPat func args ->
       return $ msingleton $ MState env loops seqs bindings (MAtom (InductivePat "apply" [func, toListPat args]) target matcher:trees)
@@ -1395,7 +1395,7 @@ primitiveDataPatternMatch (PDSnocPat pattern pattern') whnf = do
   (++) <$> primitiveDataPatternMatch pattern init'
        <*> primitiveDataPatternMatch pattern' last'
 primitiveDataPatternMatch (PDConstantPat expr) whnf = do
-  target <- (either (const matchFail) return . extractPrimitiveValue) whnf
+  target <- (either (const matchFail) return) $ extractPrimitiveValue whnf
   isEqual <- lift $ (==) <$> evalExprDeep nullEnv expr <*> pure target
   if isEqual then return [] else matchFail
 
@@ -1403,7 +1403,7 @@ expandCollection :: WHNFData -> EgisonM (Seq Inner)
 expandCollection (Value (Collection vals)) =
   mapM (fmap IElement . newEvaluatedObjectRef . Value) vals
 expandCollection (Intermediate (ICollection innersRef)) = liftIO $ readIORef innersRef
-expandCollection val = throwError $ TypeMismatch "collection" val
+expandCollection val = throwError =<< TypeMismatch "collection" val <$> getFuncNameStack
 
 isEmptyCollection :: WHNFData -> EgisonM Bool
 isEmptyCollection (Value (Collection col)) = return $ Sq.null col
@@ -1469,7 +1469,7 @@ evalMatcherWHNF (Intermediate (ITuple refs)) = do
   whnfs <- mapM evalRef refs
   ms <- mapM evalMatcherWHNF whnfs
   return $ Tuple ms
-evalMatcherWHNF whnf = throwError $ TypeMismatch "matcher" whnf
+evalMatcherWHNF whnf = throwError =<< TypeMismatch "matcher" whnf <$> getFuncNameStack
 
 --
 -- Util
@@ -1504,7 +1504,7 @@ fromCollection whnf@(Intermediate (ICollection _)) = do
       (head, tail) <- fromJust <$> runMaybeT (unconsCollection whnf)
       tail' <- evalRef tail
       return $ MCons head (fromCollection tail')
-fromCollection whnf = throwError $ TypeMismatch "collection" whnf
+fromCollection whnf = throwError =<< TypeMismatch "collection" whnf <$> getFuncNameStack
 
 tupleToList :: WHNFData -> EgisonM [EgisonValue]
 tupleToList whnf = do
@@ -1521,7 +1521,7 @@ collectionToList whnf = do
  where
   collectionToList' :: EgisonValue -> EgisonM [EgisonValue]
   collectionToList' (Collection sq) = return $ toList sq
-  collectionToList' val = throwError $ TypeMismatch "collection" (Value val)
+  collectionToList' val = throwError =<< TypeMismatch "collection" (Value val) <$> getFuncNameStack
 
 makeTuple :: [EgisonValue] -> EgisonValue
 makeTuple []  = Tuple []
@@ -1541,11 +1541,11 @@ packStringValue (Collection seq) = do
   let ls = toList seq
   str <- mapM (\val -> case val of
                          Char c -> return c
-                         _ -> throwError $ TypeMismatch "char" (Value val))
+                         _ -> throwError =<< TypeMismatch "char" (Value val) <$> getFuncNameStack)
               ls
   return $ T.pack str
 packStringValue (Tuple [val]) = packStringValue val
-packStringValue val = throwError $ TypeMismatch "string" (Value val)
+packStringValue val = throwError =<< TypeMismatch "string" (Value val) <$> getFuncNameStack
 
 --
 -- Util
@@ -1555,7 +1555,7 @@ data EgisonHashKey =
   | CharKey Char
   | StrKey Text
 
-extractPrimitiveValue :: WHNFData -> Either EgisonError EgisonValue
+extractPrimitiveValue :: WHNFData -> Either ([String] -> EgisonError) EgisonValue
 extractPrimitiveValue (Value val@(Char _)) = return val
 extractPrimitiveValue (Value val@(Bool _)) = return val
 extractPrimitiveValue (Value val@(ScalarData _)) = return val

--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -1262,8 +1262,8 @@ processMState' (MState env loops seqs bindings (MAtom pattern target matcher:tre
             IndexedPat _ _ -> return $ msingleton $ MState env loops seqs bindings (MAtom pattern target Something:trees)
             TuplePat patterns -> do
               targets <- fromTupleWHNF target
-              when (length patterns /= length targets) $ throwError $ ArgumentsNum (length patterns) (length targets)
-              when (length patterns /= length matchers) $ throwError $ ArgumentsNum (length patterns) (length matchers)
+              when (length patterns /= length targets) $ throwError =<< ArgumentsNum (length patterns) (length targets) <$> getFuncNameStack
+              when (length patterns /= length matchers) $ throwError =<< ArgumentsNum (length patterns) (length matchers) <$> getFuncNameStack
               let trees' = zipWith3 MAtom patterns targets matchers ++ trees
               return $ msingleton $ MState env loops seqs bindings trees'
             _ ->  throwError $ Default $ "should not reach here. matcher: " ++ show matcher ++ ", pattern:  " ++ show pattern
@@ -1310,7 +1310,7 @@ processMState' (MState env loops seqs bindings (MAtom pattern target matcher:tre
             IndexedPat pattern indices -> throwError $ Default ("invalid indexed-pattern: " ++ show pattern)
             TuplePat patterns -> do
               targets <- fromTupleWHNF target
-              when (length patterns /= length targets) $ throwError $ ArgumentsNum (length patterns) (length targets)
+              when (length patterns /= length targets) $ throwError =<< ArgumentsNum (length patterns) (length targets) <$> getFuncNameStack
               let trees' = zipWith3 MAtom patterns targets (replicate (length patterns) Something) ++ trees
               return $ msingleton $ MState env loops seqs bindings trees'
             _ -> throwError $ Default $ "something can only match with a pattern variable. not: " ++ show pattern

--- a/hs-src/Language/Egison/Primitives.hs
+++ b/hs-src/Language/Egison/Primitives.hs
@@ -63,7 +63,7 @@ noArg f args = do
     args' <- tupleToList args
     case args' of
       [] -> Value <$> f
-      _  -> throwError $ ArgumentsNumPrimitive 0 $ length args'
+      _  -> throwError =<< ArgumentsNumPrimitive 0 (length args') <$> getFuncNameStack
 
 {-# INLINE oneArg #-}
 oneArg :: (EgisonValue -> EgisonM EgisonValue) -> PrimitiveFunc
@@ -94,7 +94,7 @@ twoArgs f args = do
       ds' <- V.mapM (f val) ds
       Value <$> fromTensor (Tensor ns ds' js)
     [val, val'] -> Value <$> f val val'
-    _ -> throwError $ ArgumentsNumPrimitive 2 $ length args'
+    _ -> throwError =<< ArgumentsNumPrimitive 2 (length args') <$> getFuncNameStack
 
 {-# INLINE twoArgs' #-}
 twoArgs' :: (EgisonValue -> EgisonValue -> EgisonM EgisonValue) -> PrimitiveFunc
@@ -102,7 +102,7 @@ twoArgs' f args = do
   args' <- tupleToList args
   case args' of
     [val, val'] -> Value <$> f val val'
-    _           -> throwError $ ArgumentsNumPrimitive 2 $ length args'
+    _           -> throwError =<< ArgumentsNumPrimitive 2 (length args') <$> getFuncNameStack
 
 {-# INLINE threeArgs' #-}
 threeArgs' :: (EgisonValue -> EgisonValue -> EgisonValue -> EgisonM EgisonValue) -> PrimitiveFunc
@@ -110,7 +110,7 @@ threeArgs' f args = do
   args' <- tupleToList args
   case args' of
     [val, val', val''] -> Value <$> f val val' val''
-    _                  -> throwError $ ArgumentsNumPrimitive 3 $ length args'
+    _                  -> throwError =<< ArgumentsNumPrimitive 3 (length args') <$> getFuncNameStack
 
 --
 -- Constants

--- a/hs-src/Language/Egison/Types.hs
+++ b/hs-src/Language/Egison/Types.hs
@@ -1444,6 +1444,7 @@ instance (EgisonData a, EgisonData b, EgisonData c, EgisonData d) => EgisonData 
     return (x', y', z', w')
   fromEgison val = throwError =<< TypeMismatch "two elements tuple" (Value val) <$> getFuncNameStack
 
+-- TODO(momohatt): inline these functions
 fromCharValue :: EgisonValue -> EgisonM Char
 fromCharValue (Char c) = return c
 fromCharValue val      = throwError =<< TypeMismatch "char" (Value val) <$> getFuncNameStack
@@ -1548,6 +1549,7 @@ instance EgisonWHNF Double where
 instance EgisonWHNF Handle where
   fromWHNF = fromPortWHNF
 
+-- TODO(momohatt): inline these functions
 fromCharWHNF :: WHNFData -> EgisonM Char
 fromCharWHNF (Value (Char c)) = return c
 fromCharWHNF whnf             = throwError =<< TypeMismatch "char" whnf <$> getFuncNameStack
@@ -1684,10 +1686,12 @@ data SeqPatContext = SeqPatContext [MatchingTree] EgisonPattern [Matcher] [WHNFD
 -- Errors
 --
 
+type CallStack = [String]
+
 data EgisonError =
     UnboundVariable String
-  | TypeMismatch String WHNFData [String]
-  | ArgumentsNumWithNames [String] Int Int
+  | TypeMismatch String WHNFData CallStack
+  | ArgumentsNumWithNames [String] Int Int CallStack
   | ArgumentsNumPrimitive Int Int
   | ArgumentsNum Int Int
   | InconsistentTensorSize
@@ -1697,20 +1701,21 @@ data EgisonError =
   | Assertion String
   | Parser String
   | EgisonBug String
-  | MatchFailure String [String]
+  | MatchFailure String CallStack
   | Default String
   deriving Typeable
 
 instance Show EgisonError where
   show (UnboundVariable var) = "Unbound variable: " ++ show var
-  show (TypeMismatch expected found stack) = "Expected " ++  expected ++ ", but found: " ++ show found ++
-                                             "\n  stack trace: " ++ intercalate ", " stack
-  show (ArgumentsNumWithNames names expected got) = "Wrong number of arguments: " ++ show names ++ ": expected " ++
-                                                    show expected ++ ", but got " ++  show got
-  show (ArgumentsNumPrimitive expected got) = "Wrong number of arguments for a primitive function: expected " ++
-                                              show expected ++ ", but got " ++  show got
-  show (ArgumentsNum expected got) = "Wrong number of arguments: expected " ++
-                                      show expected ++ ", but got " ++  show got
+  show (TypeMismatch expected found stack) =
+    "Expected " ++  expected ++ ", but found: " ++ show found ++ "\n  stack trace: " ++ intercalate ", " stack
+  show (ArgumentsNumWithNames names expected got stack) =
+    "Wrong number of arguments: " ++ show names ++ ": expected " ++ show expected ++ ", but got " ++  show got ++
+      "\n  stack trace: " ++ intercalate ", " stack
+  show (ArgumentsNumPrimitive expected got) =
+    "Wrong number of arguments for a primitive function: expected " ++ show expected ++ ", but got " ++  show got
+  show (ArgumentsNum expected got) =
+    "Wrong number of arguments: expected " ++ show expected ++ ", but got " ++  show got
   show InconsistentTensorSize = "Inconsistent tensor size"
   show InconsistentTensorIndex = "Inconsistent tensor index"
   show (TensorIndexOutOfBounds m n) = "Tensor index out of bounds: " ++ show m ++ ", " ++ show n

--- a/hs-src/Language/Egison/Types.hs
+++ b/hs-src/Language/Egison/Types.hs
@@ -562,15 +562,15 @@ egisonToScalarData s1@(InductiveData "Quote" _) = do
 egisonToScalarData s1@(InductiveData "Function" _) = do
   s1' <- egisonToSymbolExpr (Tuple [s1, toEgison (1 :: Integer)])
   return $ Div (Plus [Term 1 [s1']]) (Plus [Term 1 []])
-egisonToScalarData val = liftError $ throwError $ TypeMismatch "math expression" (Value val)
+egisonToScalarData val = throwError =<< TypeMismatch "math expression" (Value val) <$> getFuncNameStack
 
 egisonToPolyExpr :: EgisonValue -> EgisonM PolyExpr
 egisonToPolyExpr (InductiveData "Plus" [Collection ts]) = Plus <$> mapM egisonToTermExpr (toList ts)
-egisonToPolyExpr val = liftError $ throwError $ TypeMismatch "math poly expression" (Value val)
+egisonToPolyExpr val = throwError =<< TypeMismatch "math poly expression" (Value val) <$> getFuncNameStack
 
 egisonToTermExpr :: EgisonValue -> EgisonM TermExpr
 egisonToTermExpr (InductiveData "Term" [n, Collection ts]) = Term <$> fromEgison n <*> mapM egisonToSymbolExpr (toList ts)
-egisonToTermExpr val = liftError $ throwError $ TypeMismatch "math term expression" (Value val)
+egisonToTermExpr val = throwError =<< TypeMismatch "math term expression" (Value val) <$> getFuncNameStack
 
 egisonToSymbolExpr :: EgisonValue -> EgisonM (SymbolExpr, Integer)
 egisonToSymbolExpr (Tuple [InductiveData "Symbol" [x, Collection seq], n]) = do
@@ -579,7 +579,7 @@ egisonToSymbolExpr (Tuple [InductiveData "Symbol" [x, Collection seq], n]) = do
                        InductiveData "Sup" [ScalarData k] -> return (Superscript k)
                        InductiveData "Sub" [ScalarData k] -> return (Subscript k)
                        InductiveData "User" [ScalarData k] -> return (Userscript k)
-                       _ -> liftError $ throwError $ TypeMismatch "math symbol expression" (Value j)
+                       _ -> throwError =<< TypeMismatch "math symbol expression" (Value j) <$> getFuncNameStack
                ) js
   n' <- fromEgison n
   case x of
@@ -599,14 +599,14 @@ egisonToSymbolExpr (Tuple [InductiveData "Function" [name, Collection argnames, 
                          InductiveData "Sup" [ScalarData k] -> return (Superscript k)
                          InductiveData "Sub" [ScalarData k] -> return (Subscript k)
                          InductiveData "User" [ScalarData k] -> return (Userscript k)
-                         _ -> liftError $ throwError $ TypeMismatch "math symbol expression" (Value j)
+                         _ -> throwError =<< TypeMismatch "math symbol expression" (Value j) <$> getFuncNameStack
                ) js
   n' <- fromEgison n
   let name' = case getSymName name of
                 "" -> Nothing
                 s  -> Just name
   return (FunctionData name' (toList argnames) (toList args) js', n')
-egisonToSymbolExpr val = liftError $ throwError $ TypeMismatch "math symbol expression" (Value val)
+egisonToSymbolExpr val = throwError =<< TypeMismatch "math symbol expression" (Value val) <$> getFuncNameStack
 
 mathNormalize' :: ScalarData -> ScalarData
 mathNormalize' mExpr = mathDivide (mathRemoveZero (mathFold (mathRemoveZeroSymbol mExpr)))
@@ -782,11 +782,11 @@ mathDenominator (Div _ n) = Div n (Plus [Term 1 []])
 
 extractScalar :: EgisonValue -> EgisonM ScalarData
 extractScalar (ScalarData mExpr) = return mExpr
-extractScalar val = throwError $ TypeMismatch "math expression" (Value val)
+extractScalar val = throwError =<< TypeMismatch "math expression" (Value val) <$> getFuncNameStack
 
 extractScalar' :: WHNFData -> EgisonM ScalarData
 extractScalar' (Value (ScalarData x)) = return x
-extractScalar' val = throwError $ TypeMismatch "integer or string" val
+extractScalar' val = throwError =<< TypeMismatch "integer or string" val <$> getFuncNameStack
 
 --
 -- Tensors
@@ -1383,47 +1383,47 @@ class EgisonData a where
 
 instance EgisonData Char where
   toEgison = Char
-  fromEgison = liftError . fromCharValue
+  fromEgison = fromCharValue
 
 instance EgisonData Text where
   toEgison = String
-  fromEgison = liftError . fromStringValue
+  fromEgison = fromStringValue
 
 instance EgisonData Bool where
   toEgison = Bool
-  fromEgison = liftError . fromBoolValue
+  fromEgison = fromBoolValue
 
 instance EgisonData Integer where
   toEgison 0 = ScalarData $ mathNormalize' (Div (Plus []) (Plus [Term 1 []]))
   toEgison i = ScalarData $ mathNormalize' (Div (Plus [Term i []]) (Plus [Term 1 []]))
-  fromEgison = liftError . fromIntegerValue
+  fromEgison = fromIntegerValue
 
 instance EgisonData Rational where
   toEgison r = ScalarData $ mathNormalize' (Div (Plus [Term (numerator r) []]) (Plus [Term (denominator r) []]))
-  fromEgison = liftError . fromRationalValue
+  fromEgison = fromRationalValue
 
 instance EgisonData Double where
   toEgison f = Float f 0
-  fromEgison = liftError . fromFloatValue
+  fromEgison = fromFloatValue
 
 instance EgisonData Handle where
   toEgison = Port
-  fromEgison = liftError . fromPortValue
+  fromEgison = fromPortValue
 
 instance (EgisonData a) => EgisonData [a] where
   toEgison xs = Collection $ Sq.fromList (map toEgison xs)
   fromEgison (Collection seq) = mapM fromEgison (toList seq)
-  fromEgison val = liftError $ throwError $ TypeMismatch "collection" (Value val)
+  fromEgison val = throwError =<< TypeMismatch "collection" (Value val) <$> getFuncNameStack
 
 instance EgisonData () where
   toEgison () = Tuple []
   fromEgison (Tuple []) = return ()
-  fromEgison val = liftError $ throwError $ TypeMismatch "zero element tuple" (Value val)
+  fromEgison val = throwError =<< TypeMismatch "zero element tuple" (Value val) <$> getFuncNameStack
 
 instance (EgisonData a, EgisonData b) => EgisonData (a, b) where
   toEgison (x, y) = Tuple [toEgison x, toEgison y]
   fromEgison (Tuple [x, y]) = liftM2 (,) (fromEgison x) (fromEgison y)
-  fromEgison val = liftError $ throwError $ TypeMismatch "two elements tuple" (Value val)
+  fromEgison val = throwError =<< TypeMismatch "two elements tuple" (Value val) <$> getFuncNameStack
 
 instance (EgisonData a, EgisonData b, EgisonData c) => EgisonData (a, b, c) where
   toEgison (x, y, z) = Tuple [toEgison x, toEgison y, toEgison z]
@@ -1432,7 +1432,7 @@ instance (EgisonData a, EgisonData b, EgisonData c) => EgisonData (a, b, c) wher
     y' <- fromEgison y
     z' <- fromEgison z
     return (x', y', z')
-  fromEgison val = liftError $ throwError $ TypeMismatch "two elements tuple" (Value val)
+  fromEgison val = throwError =<< TypeMismatch "two elements tuple" (Value val) <$> getFuncNameStack
 
 instance (EgisonData a, EgisonData b, EgisonData c, EgisonData d) => EgisonData (a, b, c, d) where
   toEgison (x, y, z, w) = Tuple [toEgison x, toEgison y, toEgison z, toEgison w]
@@ -1442,37 +1442,37 @@ instance (EgisonData a, EgisonData b, EgisonData c, EgisonData d) => EgisonData 
     z' <- fromEgison z
     w' <- fromEgison w
     return (x', y', z', w')
-  fromEgison val = liftError $ throwError $ TypeMismatch "two elements tuple" (Value val)
+  fromEgison val = throwError =<< TypeMismatch "two elements tuple" (Value val) <$> getFuncNameStack
 
-fromCharValue :: EgisonValue -> Either EgisonError Char
+fromCharValue :: EgisonValue -> EgisonM Char
 fromCharValue (Char c) = return c
-fromCharValue val      = throwError $ TypeMismatch "char" (Value val)
+fromCharValue val      = throwError =<< TypeMismatch "char" (Value val) <$> getFuncNameStack
 
-fromStringValue :: EgisonValue -> Either EgisonError Text
+fromStringValue :: EgisonValue -> EgisonM Text
 fromStringValue (String str) = return str
-fromStringValue val          = throwError $ TypeMismatch "string" (Value val)
+fromStringValue val          = throwError =<< TypeMismatch "string" (Value val) <$> getFuncNameStack
 
-fromBoolValue :: EgisonValue -> Either EgisonError Bool
+fromBoolValue :: EgisonValue -> EgisonM Bool
 fromBoolValue (Bool b) = return b
-fromBoolValue val      = throwError $ TypeMismatch "bool" (Value val)
+fromBoolValue val      = throwError =<< TypeMismatch "bool" (Value val) <$> getFuncNameStack
 
-fromIntegerValue :: EgisonValue -> Either EgisonError Integer
+fromIntegerValue :: EgisonValue -> EgisonM Integer
 fromIntegerValue (ScalarData (Div (Plus []) (Plus [Term 1 []]))) = return 0
 fromIntegerValue (ScalarData (Div (Plus [Term x []]) (Plus [Term 1 []]))) = return x
-fromIntegerValue val = throwError $ TypeMismatch "integer" (Value val)
+fromIntegerValue val = throwError =<< TypeMismatch "integer" (Value val) <$> getFuncNameStack
 
-fromRationalValue :: EgisonValue -> Either EgisonError Rational
+fromRationalValue :: EgisonValue -> EgisonM Rational
 fromRationalValue (ScalarData (Div (Plus []) _)) = return 0
 fromRationalValue (ScalarData (Div (Plus [Term x []]) (Plus [Term y []]))) = return (x % y)
-fromRationalValue val = throwError $ TypeMismatch "rational" (Value val)
+fromRationalValue val = throwError =<< TypeMismatch "rational" (Value val) <$> getFuncNameStack
 
-fromFloatValue :: EgisonValue -> Either EgisonError Double
+fromFloatValue :: EgisonValue -> EgisonM Double
 fromFloatValue (Float f 0) = return f
-fromFloatValue val         = throwError $ TypeMismatch "float" (Value val)
+fromFloatValue val         = throwError =<< TypeMismatch "float" (Value val) <$> getFuncNameStack
 
-fromPortValue :: EgisonValue -> Either EgisonError Handle
+fromPortValue :: EgisonValue -> EgisonM Handle
 fromPortValue (Port h) = return h
-fromPortValue val      = throwError $ TypeMismatch "port" (Value val)
+fromPortValue val      = throwError =<< TypeMismatch "port" (Value val) <$> getFuncNameStack
 
 --
 -- Internal Data
@@ -1531,47 +1531,47 @@ class (EgisonData a) => EgisonWHNF a where
   toWHNF = Value . toEgison
 
 instance EgisonWHNF Char where
-  fromWHNF = liftError . fromCharWHNF
+  fromWHNF = fromCharWHNF
 
 instance EgisonWHNF Text where
-  fromWHNF = liftError . fromStringWHNF
+  fromWHNF = fromStringWHNF
 
 instance EgisonWHNF Bool where
-  fromWHNF = liftError . fromBoolWHNF
+  fromWHNF = fromBoolWHNF
 
 instance EgisonWHNF Integer where
-  fromWHNF = liftError . fromIntegerWHNF
+  fromWHNF = fromIntegerWHNF
 
 instance EgisonWHNF Double where
-  fromWHNF = liftError . fromFloatWHNF
+  fromWHNF = fromFloatWHNF
 
 instance EgisonWHNF Handle where
-  fromWHNF = liftError . fromPortWHNF
+  fromWHNF = fromPortWHNF
 
-fromCharWHNF :: WHNFData -> Either EgisonError Char
+fromCharWHNF :: WHNFData -> EgisonM Char
 fromCharWHNF (Value (Char c)) = return c
-fromCharWHNF whnf             = throwError $ TypeMismatch "char" whnf
+fromCharWHNF whnf             = throwError =<< TypeMismatch "char" whnf <$> getFuncNameStack
 
-fromStringWHNF :: WHNFData -> Either EgisonError Text
+fromStringWHNF :: WHNFData -> EgisonM Text
 fromStringWHNF (Value (String str)) = return str
-fromStringWHNF whnf                 = throwError $ TypeMismatch "string" whnf
+fromStringWHNF whnf                 = throwError =<< TypeMismatch "string" whnf <$> getFuncNameStack
 
-fromBoolWHNF :: WHNFData -> Either EgisonError Bool
+fromBoolWHNF :: WHNFData -> EgisonM Bool
 fromBoolWHNF (Value (Bool b)) = return b
-fromBoolWHNF whnf             = throwError $ TypeMismatch "bool" whnf
+fromBoolWHNF whnf             = throwError =<< TypeMismatch "bool" whnf <$> getFuncNameStack
 
-fromIntegerWHNF :: WHNFData -> Either EgisonError Integer
+fromIntegerWHNF :: WHNFData -> EgisonM Integer
 fromIntegerWHNF (Value (ScalarData (Div (Plus []) (Plus [Term 1 []])))) = return 0
 fromIntegerWHNF (Value (ScalarData (Div (Plus [Term x []]) (Plus [Term 1 []])))) = return x
-fromIntegerWHNF whnf = throwError $ TypeMismatch "integer" whnf
+fromIntegerWHNF whnf = throwError =<< TypeMismatch "integer" whnf <$> getFuncNameStack
 
-fromFloatWHNF :: WHNFData -> Either EgisonError Double
+fromFloatWHNF :: WHNFData -> EgisonM Double
 fromFloatWHNF (Value (Float f 0)) = return f
-fromFloatWHNF whnf                = throwError $ TypeMismatch "float" whnf
+fromFloatWHNF whnf                = throwError =<< TypeMismatch "float" whnf <$> getFuncNameStack
 
-fromPortWHNF :: WHNFData -> Either EgisonError Handle
+fromPortWHNF :: WHNFData -> EgisonM Handle
 fromPortWHNF (Value (Port h)) = return h
-fromPortWHNF whnf             = throwError $ TypeMismatch "port" whnf
+fromPortWHNF whnf             = throwError =<< TypeMismatch "port" whnf <$> getFuncNameStack
 
 class (EgisonWHNF a) => EgisonObject a where
   toObject :: a -> Object
@@ -1686,7 +1686,7 @@ data SeqPatContext = SeqPatContext [MatchingTree] EgisonPattern [Matcher] [WHNFD
 
 data EgisonError =
     UnboundVariable String
-  | TypeMismatch String WHNFData
+  | TypeMismatch String WHNFData [String]
   | ArgumentsNumWithNames [String] Int Int
   | ArgumentsNumPrimitive Int Int
   | ArgumentsNum Int Int
@@ -1703,8 +1703,8 @@ data EgisonError =
 
 instance Show EgisonError where
   show (UnboundVariable var) = "Unbound variable: " ++ show var
-  show (TypeMismatch expected found) = "Expected " ++  expected ++
-                                        ", but found: " ++ show found
+  show (TypeMismatch expected found stack) = "Expected " ++  expected ++ ", but found: " ++ show found ++
+                                             "\n  stack trace: " ++ intercalate ", " stack
   show (ArgumentsNumWithNames names expected got) = "Wrong number of arguments: " ++ show names ++ ": expected " ++
                                                     show expected ++ ", but got " ++  show got
   show (ArgumentsNumPrimitive expected got) = "Wrong number of arguments for a primitive function: expected " ++

--- a/hs-src/Language/Egison/Types.hs
+++ b/hs-src/Language/Egison/Types.hs
@@ -1692,8 +1692,8 @@ data EgisonError =
     UnboundVariable String
   | TypeMismatch String WHNFData CallStack
   | ArgumentsNumWithNames [String] Int Int CallStack
-  | ArgumentsNumPrimitive Int Int
-  | ArgumentsNum Int Int
+  | ArgumentsNumPrimitive Int Int CallStack
+  | ArgumentsNum Int Int CallStack
   | InconsistentTensorSize
   | InconsistentTensorIndex
   | TensorIndexOutOfBounds Integer Integer
@@ -1708,14 +1708,17 @@ data EgisonError =
 instance Show EgisonError where
   show (UnboundVariable var) = "Unbound variable: " ++ show var
   show (TypeMismatch expected found stack) =
-    "Expected " ++  expected ++ ", but found: " ++ show found ++ "\n  stack trace: " ++ intercalate ", " stack
+    "Expected " ++  expected ++ ", but found: " ++ show found
+    ++ "\n  stack trace: " ++ intercalate ", " stack
   show (ArgumentsNumWithNames names expected got stack) =
-    "Wrong number of arguments: " ++ show names ++ ": expected " ++ show expected ++ ", but got " ++  show got ++
-      "\n  stack trace: " ++ intercalate ", " stack
-  show (ArgumentsNumPrimitive expected got) =
+    "Wrong number of arguments: " ++ show names ++ ": expected " ++ show expected ++ ", but got " ++  show got
+    ++ "\n  stack trace: " ++ intercalate ", " stack
+  show (ArgumentsNumPrimitive expected got stack) =
     "Wrong number of arguments for a primitive function: expected " ++ show expected ++ ", but got " ++  show got
-  show (ArgumentsNum expected got) =
+    ++ "\n  stack trace: " ++ intercalate ", " stack
+  show (ArgumentsNum expected got stack) =
     "Wrong number of arguments: expected " ++ show expected ++ ", but got " ++  show got
+    ++ "\n  stack trace: " ++ intercalate ", " stack
   show InconsistentTensorSize = "Inconsistent tensor size"
   show InconsistentTensorIndex = "Inconsistent tensor index"
   show (TensorIndexOutOfBounds m n) = "Tensor index out of bounds: " ++ show m ++ ", " ++ show n
@@ -1723,8 +1726,9 @@ instance Show EgisonError where
   show (Assertion message) = "Assertion failed: " ++ message
   show (Parser err) = "Parse error at: " ++ err
   show (EgisonBug message) = "Egison Error: " ++ message
-  show (MatchFailure currentFunc stack) = "Failed pattern match in: " ++ currentFunc ++
-                                          "\n  stack trace: " ++ intercalate ", " stack
+  show (MatchFailure currentFunc stack) =
+    "Failed pattern match in: " ++ currentFunc
+    ++ "\n  stack trace: " ++ intercalate ", " stack
   show (Default message) = "Error: " ++ message
 
 instance Exception EgisonError


### PR DESCRIPTION
Examples:

```
; TypeMismatch

(define $typemismatch
  (lambda [$x]
    (S.concat {"hoge" x})))

; > (typemismatch 1)
; Expected string, but found: 1
;   stack trace: foldr, foldr, typemismatch

; ArgumentsNumWithNames

(define $call-piyo
  (lambda [$x] (piyo x 1 2)))
(define $piyo (lambda [$x $y] (+ x y)))

; > (call-piyo 1)
; Wrong number of arguments: ["x","y"]: expected 2, but got 3
;   stack trace: piyo, call-piyo

; ArgumentsNum

(define $call-fuga
  (lambda [$x] (fuga x)))

(define $fuga
  (match-lambda [integer integer]
    {[[$x $y] x]}))

; > (call-fuga [1 2 3])
; Wrong number of arguments: expected 2, but got 3
;   stack trace: fuga, call-fuga

; ArgumentsNumPrimitive
(define $hoge (lambda [$x] (lt? x)))

; > (hoge 1)
; Wrong number of arguments for a primitive function: expected 2, but got 1
;   stack trace: hoge```