### PR TITLE
Delete redundant dependancy from egison.cabal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ sudo: false
 # Caching so the next build will be fast too.
 cache:
   directories:
-  - $HOME/.stack
+    - $HOME/.cabal/packages
+    - $HOME/.cabal/store
+    - $HOME/.stack
+    - $TRAVIS_BUILD_DIR/.stack-work
 
 before_install:
   # Download and unpack the stack executable

--- a/egison.cabal
+++ b/egison.cabal
@@ -68,7 +68,7 @@ source-repository head
   location: https://github.com/egison/egison.git
 
 Library
-  Build-Depends:   base >= 4.7 && < 5, array, random, containers, unordered-containers, haskeline, transformers, mtl >=2.2.1, parsec >= 3.0, directory, ghc, ghc-paths, text, regex-tdfa, process, vector, parallel, split, hashable
+  Build-Depends:   base >= 4.7 && < 5, array, random, containers, unordered-containers, haskeline, transformers, mtl >=2.2.1, parsec >= 3.0, directory, ghc, ghc-paths, text, regex-tdfa, process, vector, split, hashable
   if !impl(ghc > 8.0)
     Build-Depends: fail
   Hs-Source-Dirs:  hs-src


### PR DESCRIPTION
Also cache cabal packages in TravisCI so that the future builds will be faster.