### PR TITLE
Fixed a bug in AC.intersect and AC.intersectAs in assoc.egi

### DIFF
--- a/lib/core/assoc.egi
+++ b/lib/core/assoc.egi
@@ -87,8 +87,8 @@ assocMultiset a :=
 
 AC.intersect xs ys :=
   matchAll (xs, ys) as (assocMultiset something, assocMultiset something) with
-    | (ncons $x $m _, ncons #x $n _) -> (x, min [m, n])
+    | (ncons $x $m _, ncons #x $n _) -> (x, min m n)
 
 AC.intersectAs a xs ys :=
   matchAll (xs, ys) as (assocMultiset a, assocMultiset a) with
-    | (ncons $x $m _, ncons #x $n _) -> (x, min [m, n])
+    | (ncons $x $m _, ncons #x $n _) -> (x, min m n)


### PR DESCRIPTION
I encountered the following bug.

```
> AC.intersect [(x, 2)] [(x, 1)]
Wrong number of arguments: ["x","y"]: expected 2, but got 1
  stack trace: min, <stdin>
```

I fixed misconfiguration of arguments to `min` in the definition of `AC.intersect` and `AC.intersectAs`.