### PR TITLE
Allow primitive data pattern match at letExpr

### DIFF
--- a/hs-src/Language/Egison/AST.hs
+++ b/hs-src/Language/Egison/AST.hs
@@ -163,7 +163,7 @@ extractSupOrSubIndex _                = Nothing
 data PMMode = BFSMode | DFSMode
  deriving (Eq, Show)
 
-type BindingExpr = ([Var], Expr)
+type BindingExpr = (PrimitiveDataPattern, Expr)
 type MatchClause = (Pattern, Expr)
 type PatternDef  = (PrimitivePatPattern, Expr, [(PrimitiveDataPattern, Expr)])
 

--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -660,14 +660,14 @@ recursiveBind env bindings = do
       let ref = fromJust (refVar env' var)
       liftIO $ writeIORef ref obj
   return env'
-
-collectNames :: PrimitiveDataPattern -> [Var]
-collectNames (PDPatVar var) = [var]
-collectNames (PDInductivePat _ ps) = concatMap collectNames ps
-collectNames (PDTuplePat ps) = concatMap collectNames ps
-collectNames (PDConsPat p1 p2) = collectNames p1 ++ collectNames p2
-collectNames (PDSnocPat p1 p2) = collectNames p1 ++ collectNames p2
-collectNames _ = []
+ where
+  collectNames :: PrimitiveDataPattern -> [Var]
+  collectNames (PDPatVar var) = [var]
+  collectNames (PDInductivePat _ ps) = concatMap collectNames ps
+  collectNames (PDTuplePat ps) = concatMap collectNames ps
+  collectNames (PDConsPat p1 p2) = collectNames p1 ++ collectNames p2
+  collectNames (PDSnocPat p1 p2) = collectNames p1 ++ collectNames p2
+  collectNames _ = []
 
 --
 -- Pattern Match

--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -260,34 +260,24 @@ evalExprShallow env (IfExpr test expr expr') = do
   test <- evalExprShallow env test >>= fromWHNF
   evalExprShallow env $ if test then expr else expr'
 
-evalExprShallow env (LetExpr bindings expr) =
-  mapM extractBindings bindings >>= flip evalExprShallow expr . extendEnv env . concat
+evalExprShallow env (LetExpr bindings expr) = do
+  binding <- concat <$> mapM extractBindings bindings
+  evalExprShallow (extendEnv env binding) expr
  where
   extractBindings :: BindingExpr -> EvalM [Binding]
-  extractBindings ([name], expr) =
-    case expr of
-      FunctionExpr _ ->
-        let Env frame _ = env
-         in makeBindings [name] . (:[]) <$> newThunkRef (Env frame (Just $ varToVarWithIndices name)) expr
-      _ -> makeBindings [name] . (:[]) <$> newThunkRef env expr
-  extractBindings (names, expr) =
-    makeBindings names <$> (evalExprShallow env expr >>= tupleToRefs)
+  extractBindings (PDPatVar name, expr@FunctionExpr{}) =
+    let Env frame _ = env
+     in makeBindings [name] . (:[]) <$> newThunkRef (Env frame (Just $ varToVarWithIndices name)) expr
+  extractBindings (pdp, expr) = do
+    let thunk = newThunk env expr
+    r <- runMaybeT $ primitiveDataPatternMatch pdp thunk
+    case r of
+      Nothing -> throwError $ Default "failed primitive data pattern match"
+      Just binding -> return binding
 
 evalExprShallow env (LetRecExpr bindings expr) = do
-  bindings' <- concat <$> mapM extractBindings bindings
-  recursiveBind env bindings' >>= flip evalExprShallow expr
- where
-  extractBindings :: BindingExpr -> EvalM [(Var, Expr)]
-  extractBindings ([name], expr) = return [(name, expr)]
-  extractBindings (names, expr) = do
-    var <- stringToVar <$> fresh
-    let target = VarExpr var
-        matcher = TupleExpr $ map (const SomethingExpr) names
-        nth n =
-          let pattern = TuplePat $ flip map [1..length names] $ \i ->
-                if i == n then PatVar (stringToVar "#_") else WildCard
-          in MatchExpr BFSMode target matcher [(pattern, stringToVarExpr "#_")]
-    return ((var, expr) : zipWith (\name i -> (name, nth i)) names [1..])
+  env' <- recursiveBind env bindings
+  evalExprShallow env' expr
 
 evalExprShallow env (TransposeExpr vars expr) = do
   syms <- evalExprDeep env vars >>= collectionToList
@@ -330,7 +320,7 @@ evalExprShallow env (DoExpr bindings expr) = return $ Value $ IOFunc $ do
   applyFunc env (Value $ Func Nothing env ["#1"] body) $ Value World
  where
   genLet (names, expr) expr' =
-    LetExpr [(map stringToVar ["#1", "#2"], ApplyExpr expr $ TupleExpr [stringToVarExpr "#1"])] $
+    LetExpr [(PDTuplePat (map (PDPatVar . stringToVar) ["#1", "#2"]), ApplyExpr expr $ TupleExpr [stringToVarExpr "#1"])] $
     LetExpr [(names, stringToVarExpr "#2")] expr'
 
 evalExprShallow env (IoExpr expr) = do
@@ -649,15 +639,25 @@ refHash val (index:indices) =
       Just ref -> evalRef ref >>= flip refHash indices
       Nothing  -> return $ Value Undefined
 
-newThunkRef :: Env -> Expr -> EvalM ObjectRef
-newThunkRef env expr = liftIO . newIORef . Thunk $ evalExprShallow env expr
+newThunk :: Env -> Expr -> Object
+newThunk env expr = Thunk $ evalExprShallow env expr
 
-recursiveBind :: Env -> [(Var, Expr)] -> EvalM Env
+newThunkRef :: Env -> Expr -> EvalM ObjectRef
+newThunkRef env expr = liftIO . newIORef $ newThunk env expr
+
+recursiveBind :: Env -> [BindingExpr] -> EvalM Env
 recursiveBind env bindings = do
-  let (names, _) = unzip bindings
-  refs <- replicateM (length bindings) $ newThunkRef nullEnv UndefinedExpr
-  let env' = extendEnv env $ makeBindings names refs
-  zipWithM_ (f env') refs bindings
+  let names = concatMap (\(pd, _) -> collectNames pd) bindings
+  binds <- mapM (\name -> (name, ) <$> newThunkRef nullEnv UndefinedExpr) names
+  let env' = extendEnv env binds
+  forM_ bindings $ \(pd, expr) -> do
+    binds <- runMaybeT $ primitiveDataPatternMatch pd (newThunk env' expr)
+    case binds of
+      Just binds -> forM_ binds $ \(var, objref) -> do
+        obj <- liftIO $ readIORef objref
+        let ref = fromJust (refVar env' var)
+        liftIO $ writeIORef ref obj
+      Nothing -> return ()
   return env'
  where
   f (Env frame _) ref (name, expr@FunctionExpr{}) =
@@ -666,6 +666,14 @@ recursiveBind env bindings = do
     liftIO . writeIORef ref . Thunk $ evalExprShallow env' expr
   f (Env frame _) ref (name, expr) =
     liftIO . writeIORef ref . Thunk $ evalExprShallow (Env frame (Just $ varToVarWithIndices name)) expr
+
+collectNames :: PrimitiveDataPattern -> [Var]
+collectNames (PDPatVar var) = [var]
+collectNames (PDInductivePat _ ps) = concatMap collectNames ps
+collectNames (PDTuplePat ps) = concatMap collectNames ps
+collectNames (PDConsPat p1 p2) = collectNames p1 ++ collectNames p2
+collectNames (PDSnocPat p1 p2) = collectNames p1 ++ collectNames p2
+collectNames _ = []
 
 --
 -- Pattern Match
@@ -816,8 +824,11 @@ processMState' mstate@(MState env loops seqs bindings (MAtom pattern target matc
       b <- concat <$> mapM extractBindings bindings'
       return . msingleton $ mstate { mStateBindings = b ++ bindings, mTrees = MAtom pattern' target matcher:trees }
         where
-          extractBindings ([name], expr) = makeBindings [name] . (:[]) <$> newThunkRef env' expr
-          extractBindings (names, expr)  = makeBindings names <$> (evalExprShallow env' expr >>= tupleToRefs)
+          extractBindings (pdp, expr) = do
+            r <- runMaybeT $ primitiveDataPatternMatch pdp (newThunk env expr)
+            case r of
+              Nothing -> throwError $ Default "failed primitive data pattern match"
+              Just binding -> return binding
 
     PredPat predicate -> do
       func <- evalExprShallow env' predicate
@@ -986,7 +997,7 @@ inductiveMatch env pattern target (UserMatcher matcherEnv clauses) =
         return (patterns, targetss, matchers)
       _ -> cont
   tryPDMatchClause bindings (pat, expr) cont = do
-    result <- runMaybeT $ primitiveDataPatternMatch pat target
+    result <- runMaybeT $ primitiveDataPatternMatch pat (WHNF target)
     case result of
       Just bindings' -> do
         let env = extendEnv matcherEnv $ bindings ++ bindings'
@@ -1012,49 +1023,54 @@ primitivePatPatternMatch env (PPTuplePat patterns) (TuplePat exprs)
   | otherwise = matchFail
 primitivePatPatternMatch _ _ _ = matchFail
 
-primitiveDataPatternMatch :: PrimitiveDataPattern -> WHNFData -> MatchM [Binding]
+primitiveDataPatternMatch :: PrimitiveDataPattern -> Object -> MatchM [Binding]
 primitiveDataPatternMatch PDWildCard _ = return []
-primitiveDataPatternMatch (PDPatVar var) whnf = do
-  ref <- lift $ newEvaluatedObjectRef whnf
-  return [(var, ref)]
-primitiveDataPatternMatch (PDInductivePat name patterns) whnf =
-  case whnf of
-    Intermediate (IInductiveData name' refs) | name == name' -> do
-      whnfs <- lift $ mapM evalRef refs
-      concat <$> zipWithM primitiveDataPatternMatch patterns whnfs
-    Value (InductiveData name' vals) | name == name' -> do
-      let whnfs = map Value vals
-      concat <$> zipWithM primitiveDataPatternMatch patterns whnfs
-    _ -> matchFail
-primitiveDataPatternMatch (PDTuplePat patterns) whnf =
-  case whnf of
-    Intermediate (ITuple refs) -> do
-      whnfs <- lift $ mapM evalRef refs
-      concat <$> zipWithM primitiveDataPatternMatch patterns whnfs
-    Value (Tuple vals) -> do
-      let whnfs = map Value vals
-      concat <$> zipWithM primitiveDataPatternMatch patterns whnfs
-    _ -> matchFail
-primitiveDataPatternMatch PDEmptyPat whnf = do
-  isEmpty <- lift $ isEmptyCollection whnf
-  if isEmpty then return [] else matchFail
-primitiveDataPatternMatch (PDConsPat pattern pattern') whnf = do
-  (head, tail) <- unconsCollection whnf
-  head' <- lift $ evalRef head
-  tail' <- lift $ evalRef tail
-  (++) <$> primitiveDataPatternMatch pattern head'
-       <*> primitiveDataPatternMatch pattern' tail'
-primitiveDataPatternMatch (PDSnocPat pattern pattern') whnf = do
-  (init, last) <- unsnocCollection whnf
-  init' <- lift $ evalRef init
-  last' <- lift $ evalRef last
-  (++) <$> primitiveDataPatternMatch pattern init'
-       <*> primitiveDataPatternMatch pattern' last'
-primitiveDataPatternMatch (PDConstantPat expr) whnf = do
-  target <- either (const matchFail) return $ extractPrimitiveValue whnf
-  isEqual <- lift $ (==) <$> evalExprDeep nullEnv expr <*> pure target
-  if isEqual then return [] else matchFail
+primitiveDataPatternMatch (PDPatVar name) obj = do
+  ref <- liftIO (newIORef obj)
+  return [(name, ref)]
+primitiveDataPatternMatch pdp (Thunk thunk) = do
+  whnf <- lift thunk
+  pdpmWHNF pdp whnf
  where
+  pdpmWHNF :: PrimitiveDataPattern -> WHNFData -> MatchM [Binding]
+  pdpmWHNF (PDInductivePat name patterns) whnf =
+    case whnf of
+      Intermediate (IInductiveData name' refs) | name == name' -> do
+        whnfs <- lift $ mapM evalRef refs
+        concat <$> zipWithM pdpmWHNF patterns whnfs
+      Value (InductiveData name' vals) | name == name' -> do
+        let whnfs = map Value vals
+        concat <$> zipWithM pdpmWHNF patterns whnfs
+      _ -> matchFail
+  pdpmWHNF (PDTuplePat patterns) whnf =
+    case whnf of
+      Intermediate (ITuple refs) -> do
+        whnfs <- lift $ mapM evalRef refs
+        concat <$> zipWithM pdpmWHNF patterns whnfs
+      Value (Tuple vals) -> do
+        let whnfs = map Value vals
+        concat <$> zipWithM pdpmWHNF patterns whnfs
+      _ -> matchFail
+  pdpmWHNF PDEmptyPat whnf = do
+    isEmpty <- lift $ isEmptyCollection whnf
+    if isEmpty then return [] else matchFail
+  pdpmWHNF (PDConsPat pattern pattern') whnf = do
+    (head, tail) <- unconsCollection whnf
+    head' <- lift $ evalRef head
+    tail' <- lift $ evalRef tail
+    (++) <$> pdpmWHNF pattern head'
+         <*> pdpmWHNF pattern' tail'
+  pdpmWHNF (PDSnocPat pattern pattern') whnf = do
+    (init, last) <- unsnocCollection whnf
+    init' <- lift $ evalRef init
+    last' <- lift $ evalRef last
+    (++) <$> pdpmWHNF pattern init'
+         <*> pdpmWHNF pattern' last'
+  pdpmWHNF (PDConstantPat expr) whnf = do
+    target <- either (const matchFail) return $ extractPrimitiveValue whnf
+    isEqual <- lift $ (==) <$> evalExprDeep nullEnv expr <*> pure target
+    if isEqual then return [] else matchFail
+
   extractPrimitiveValue :: WHNFData -> Either ([String] -> EgisonError) EgisonValue
   extractPrimitiveValue (Value val@(Char _)) = return val
   extractPrimitiveValue (Value val@(Bool _)) = return val

--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -824,7 +824,7 @@ processMState' mstate@(MState env loops seqs bindings (MAtom pattern target matc
       return . msingleton $ mstate { mStateBindings = b ++ bindings, mTrees = MAtom pattern' target matcher:trees }
         where
           extractBindings (pdp, expr) = do
-            thunk <- newThunkRef env expr
+            thunk <- newThunkRef (extendEnv env bindings) expr
             r <- runMaybeT $ primitiveDataPatternMatch pdp thunk
             case r of
               Nothing -> throwError $ Default "failed primitive data pattern match"

--- a/hs-src/Language/Egison/Data.hs
+++ b/hs-src/Language/Egison/Data.hs
@@ -525,7 +525,7 @@ nullEnv :: Env
 nullEnv = Env [] Nothing
 
 extendEnv :: Env -> [Binding] -> Env
-extendEnv (Env env idx) bdg = Env ((: env) $ HashMap.fromList bdg) idx
+extendEnv (Env env idx) bdg = Env (HashMap.fromList bdg : env) idx
 
 refVar :: Env -> Var -> Maybe ObjectRef
 refVar (Env env _) var@(Var _ []) = msum $ map (HashMap.lookup var) env

--- a/hs-src/Language/Egison/Desugar.hs
+++ b/hs-src/Language/Egison/Desugar.hs
@@ -370,7 +370,6 @@ desugarLoopRange (LoopRange sExpr eExpr pat) =
   LoopRange <$> desugar sExpr <*> desugar eExpr <*> desugarPattern' pat
 
 desugarBindings :: [BindingExpr] -> EvalM [BindingExpr]
-<<<<<<< HEAD
 desugarBindings = mapM f
   where
     f (name, expr) = do
@@ -378,9 +377,6 @@ desugarBindings = mapM f
       case expr' of
         LambdaExpr Nothing args body -> return (name, LambdaExpr (Just (show name)) args body)
         _                            -> return (name, expr')
-=======
-desugarBindings = mapM (\(pd, expr) -> (pd,) <$> desugar expr)
->>>>>>> wip
 
 desugarMatchClauses :: [MatchClause] -> EvalM [MatchClause]
 desugarMatchClauses = mapM (\(pat, expr) -> (,) <$> desugarPattern pat <*> desugar expr)

--- a/hs-src/Language/Egison/Parser/NonS.hs
+++ b/hs-src/Language/Egison/Parser/NonS.hs
@@ -331,14 +331,14 @@ letExpr = do
 
 binding :: Parser BindingExpr
 binding = do
-  (vars, args) <- (,[]) <$> parens (sepBy varLiteral comma)
+  (var, args) <- (,[]) <$> pdPattern
               <|> do var <- varLiteral
                      args <- many arg
-                     return ([var], args)
+                     return (PDPatVar var, args)
   body <- symbol ":=" >> expr
   return $ case args of
-             [] -> (vars, body)
-             _  -> (vars, LambdaExpr Nothing args body)
+             [] -> (var, body)
+             _  -> (var, LambdaExpr Nothing args body)
 
 withSymbolsExpr :: Parser Expr
 withSymbolsExpr = WithSymbolsExpr <$> (reserved "withSymbols" >> brackets (sepBy ident comma)) <*> expr
@@ -347,12 +347,12 @@ doExpr :: Parser Expr
 doExpr = do
   stmts <- reserved "do" >> oneLiner <|> alignSome statement
   case reverse stmts of
-    []           -> return $ DoExpr []           (makeApply "return" [])
-    ([], expr):_ -> return $ DoExpr (init stmts) expr
-    _:_          -> customFailure LastStmtInDoBlock
+    []                      -> return $ DoExpr []           (makeApply "return" [])
+    (PDTuplePat [], expr):_ -> return $ DoExpr (init stmts) expr
+    _:_                     -> customFailure LastStmtInDoBlock
   where
     statement :: Parser BindingExpr
-    statement = (reserved "let" >> binding) <|> ([],) <$> expr
+    statement = (reserved "let" >> binding) <|> (PDTuplePat [],) <$> expr
 
     oneLiner :: Parser [BindingExpr]
     oneLiner = braces $ sepBy statement (symbol ";")
@@ -689,6 +689,7 @@ pdPattern = makeExprParser pdApplyOrAtom table
     pdAtom :: Parser PrimitiveDataPattern
     pdAtom = PDWildCard    <$ symbol "_"
          <|> PDPatVar      <$> patVarLiteral
+         <|> PDPatVar      <$> varLiteral
          <|> PDConstantPat <$> constantExpr
          <|> pdCollection
          <|> makeTupleOrParen pdPattern PDTuplePat

--- a/hs-src/Language/Egison/Parser/SExpr.hs
+++ b/hs-src/Language/Egison/Parser/SExpr.hs
@@ -363,8 +363,8 @@ statements = braces $ sepEndBy statement whiteSpace
 
 statement :: Parser BindingExpr
 statement = try binding
-        <|> try (brackets (([],) <$> expr))
-        <|> (([],) <$> expr)
+        <|> try (brackets ((PDTuplePat [],) <$> expr))
+        <|> ((PDTuplePat [],) <$> expr)
 
 bindings :: Parser [BindingExpr]
 bindings = braces $ sepEndBy binding whiteSpace
@@ -376,9 +376,9 @@ varNames :: Parser [String]
 varNames = return <$> (char '$' >> ident)
             <|> brackets (sepEndBy (char '$' >> ident) whiteSpace)
 
-varNames' :: Parser [Var]
-varNames' = return <$> (char '$' >> identVar)
-            <|> brackets (sepEndBy (char '$' >> identVar) whiteSpace)
+varNames' :: Parser PrimitiveDataPattern
+varNames' = PDPatVar <$> (char '$' >> identVar)
+        <|> PDTuplePat <$> brackets (sepEndBy (PDPatVar <$> (char '$' >> identVar)) whiteSpace)
 
 argNames :: Parser [Arg]
 argNames = return <$> argName

--- a/hs-src/Language/Egison/Pretty.hs
+++ b/hs-src/Language/Egison/Pretty.hs
@@ -188,10 +188,9 @@ instance Pretty VarWithIndices where
     concatWith (surround dot) (map pretty xs) <> hcat (map pretty is)
 
 instance {-# OVERLAPPING #-} Pretty BindingExpr where
-  pretty ([var], LambdaExpr _ args body) =
-    hsep (pretty var : map pretty args) <+> indentBlock (pretty ":=") [pretty body]
-  pretty ([var], expr) = pretty var <+> pretty ":=" <+> align (pretty expr)
-  pretty (vars, expr) = tupled (map pretty vars) <+> pretty ":=" <+> align (pretty expr)
+  pretty (PDPatVar f, LambdaExpr _ args body) =
+    hsep (pretty f : map pretty args) <+> indentBlock (pretty ":=") [pretty body]
+  pretty (pat, expr) = pretty pat <+> pretty ":=" <+> align (pretty expr)
 
 instance {-# OVERLAPPING #-} Pretty MatchClause where
   pretty (pat, expr) =
@@ -279,7 +278,7 @@ instance Pretty PrimitivePatPattern where
 
 instance Pretty PrimitiveDataPattern where
   pretty PDWildCard   = pretty "_"
-  pretty (PDPatVar x) = pretty '$' <> pretty x
+  pretty (PDPatVar x) = pretty x
   pretty (PDInductivePat x pdpats) = applyLike (pretty x : map pretty' pdpats)
   pretty (PDTuplePat pdpats) = tupled (map pretty pdpats)
   pretty PDEmptyPat = pretty "[]"
@@ -374,7 +373,7 @@ pretty'' x | isAtomOrApp x || isInfix x = pretty x
 
 -- Display "hoge" instead of "() := hoge"
 prettyDoBinds :: BindingExpr -> Doc ann
-prettyDoBinds ([], expr) = pretty expr
+prettyDoBinds (PDTuplePat [], expr) = pretty expr
 prettyDoBinds (vs, expr) = pretty "let" <+> pretty (vs, expr)
 
 prettyMatch :: Expr -> [MatchClause] -> Doc ann

--- a/hs-src/Tool/translator.hs
+++ b/hs-src/Tool/translator.hs
@@ -198,7 +198,7 @@ instance SyntaxElement a => SyntaxElement (Index a) where
   toNonS script = toNonS <$> script
 
 instance SyntaxElement BindingExpr where
-  toNonS (vars, x) = (map toNonS vars, toNonS x)
+  toNonS (pdp, x) = (toNonS pdp, toNonS x)
 
 instance SyntaxElement MatchClause where
   toNonS (pat, body) = (toNonS pat, toNonS body)

--- a/test/syntax.egi
+++ b/test/syntax.egi
@@ -672,3 +672,20 @@ assertEqual "user-defined pattern infix"
 assertEqual "user-defined pattern infix"
   (match [1, 2] as dummyMatcher with $x <?> $y :: _ -> x + y)
   3
+
+-- Primitive data pattern match with let expression
+assertEqual "let pattern match"
+  (let (x :: xs) := [1, 2, 3] in (x, xs))
+  (1, [2, 3])
+
+assertEqual "let pattern match"
+  (let (snoc xs x) := [1, 2, 3] in (x, xs))
+  (3, [1, 2])
+
+assertEqual "let pattern match"
+  (let (Just x) := Just 1 in x)
+  1
+
+assertEqual "let pattern match"
+  (let (x, y) := (2, 3) in x + y)
+  5


### PR DESCRIPTION
Example:
```
let (x, y) := (1, 2) in x + y -- 3
let (Foo x) := Foo 1 in x --- 1
let (x :: _) := [1,2,3] in x -- 1
let (snoc _ x) := [1,2,3] in x -- 3
```
As you can see, primitive data patterns should be wrapped in parenthesis if they are `PDInductivePat`, `PDConsPattern`, `PDSnocPattern`.
This is necessary for parsing, especially, disambiguating the functions definitions from `PDInductivePat`.
```
let f x := 1 in f 10 -- 1
```