### PR TITLE
Deprecate "wrong number of argument" exception

### DIFF
--- a/egison.cabal
+++ b/egison.cabal
@@ -131,7 +131,10 @@ Library
                    Language.Egison.PrettyMath.Mathematica
                    Language.Egison.PrettyMath.Maxima
                    Language.Egison.Primitives
+                   Language.Egison.Primitives.Arith
+                   Language.Egison.Primitives.IO
                    Language.Egison.Primitives.Types
+                   Language.Egison.Primitives.Utils
                    Language.Egison.RState
                    Language.Egison.Tensor
   Other-modules:   Paths_egison

--- a/hs-src/Language/Egison/Data.hs
+++ b/hs-src/Language/Egison/Data.hs
@@ -33,7 +33,6 @@ module Language.Egison.Data
     , Object (..)
     , ObjectRef
     , WHNFData (..)
-    , Intermediate (..)
     , Inner (..)
     , EgisonWHNF (..)
     -- * Environment
@@ -149,13 +148,13 @@ instance HasTensor EgisonValue where
   undef = Undefined
 
 instance HasTensor WHNFData where
-  tensorElems (Intermediate (ITensor (Tensor _ xs _))) = xs
-  tensorShape (Intermediate (ITensor (Tensor ns _ _))) = ns
-  tensorIndices (Intermediate (ITensor (Tensor _ _ js))) = js
-  fromTensor t@Tensor{} = return $ Intermediate $ ITensor t
+  tensorElems (ITensor (Tensor _ xs _)) = xs
+  tensorShape (ITensor (Tensor ns _ _)) = ns
+  tensorIndices (ITensor (Tensor _ _ js)) = js
+  fromTensor t@Tensor{} = return (ITensor t)
   fromTensor (Scalar x) = return x
-  toTensor (Intermediate (ITensor t)) = return t
-  toTensor x                          = return $ Scalar x
+  toTensor (ITensor t) = return t
+  toTensor x           = return (Scalar x)
   undef = Value Undefined
 
 --
@@ -427,11 +426,8 @@ data Object
   | WHNF WHNFData
 
 data WHNFData
-  = Intermediate Intermediate
-  | Value EgisonValue
-
-data Intermediate
-  = IInductiveData String [ObjectRef]
+  = Value EgisonValue
+  | IInductiveData String [ObjectRef]
   | ITuple [ObjectRef]
   | ICollection (IORef (Seq Inner))
   | IIntHash (HashMap Integer ObjectRef)
@@ -445,14 +441,14 @@ data Inner
 
 instance Show WHNFData where
   show (Value val) = show val
-  show (Intermediate (IInductiveData name _)) = "<" ++ name ++ " ...>"
-  show (Intermediate (ITuple _)) = "[...]"
-  show (Intermediate (ICollection _)) = "{...}"
-  show (Intermediate (IIntHash _)) = "{|...|}"
-  show (Intermediate (ICharHash _)) = "{|...|}"
-  show (Intermediate (IStrHash _)) = "{|...|}"
-  show (Intermediate (ITensor (Tensor ns xs _))) = "[|" ++ show (length ns) ++ show (V.length xs) ++ "|]"
-  show (Intermediate (ITensor (Scalar _))) = "scalar"
+  show (IInductiveData name _) = "<" ++ name ++ " ...>"
+  show (ITuple _) = "(...)"
+  show (ICollection _) = "[...]"
+  show (IIntHash _) = "{|...|}"
+  show (ICharHash _) = "{|...|}"
+  show (IStrHash _) = "{|...|}"
+  show (ITensor (Tensor ns xs _)) = "[|" ++ show (length ns) ++ show (V.length xs) ++ "|]"
+  show (ITensor (Scalar _)) = "scalar"
 
 instance Show Object where
   show (Thunk _)   = "#<thunk>"

--- a/hs-src/Language/Egison/Data.hs
+++ b/hs-src/Language/Egison/Data.hs
@@ -534,7 +534,6 @@ type CallStack = [String]
 data EgisonError
   = UnboundVariable String CallStack
   | TypeMismatch String WHNFData CallStack
-  | ArgumentsNumWithNames [String] Int Int CallStack
   | ArgumentsNumPrimitive String Int Int CallStack
   | TupleLength Int Int CallStack
   | InconsistentTensorShape CallStack
@@ -553,8 +552,6 @@ instance Show EgisonError where
     "Unbound variable: " ++ show var ++ showTrace stack
   show (TypeMismatch expected found stack) =
     "Expected " ++  expected ++ ", but found: " ++ show found ++ showTrace stack
-  show (ArgumentsNumWithNames names expected got stack) =
-    "Wrong number of arguments: " ++ show names ++ ": expected " ++ show expected ++ ", but got " ++  show got ++ showTrace stack
   show (ArgumentsNumPrimitive name expected got stack) =
     "Wrong number of arguments for a primitive function '" ++ name ++ "': expected " ++ show expected ++ ", but got " ++  show got ++ showTrace stack
   show (TupleLength expected got stack) =

--- a/hs-src/Language/Egison/Data/Utils.hs
+++ b/hs-src/Language/Egison/Data/Utils.hs
@@ -47,14 +47,14 @@ makeBindings' :: [String] -> [ObjectRef] -> [Binding]
 makeBindings' xs = zip (map stringToVar xs)
 
 tupleToRefs :: WHNFData -> EvalM [ObjectRef]
-tupleToRefs (Intermediate (ITuple refs)) = return refs
+tupleToRefs (ITuple refs) = return refs
 tupleToRefs (Value (Tuple vals)) = mapM (newEvaluatedObjectRef . Value) vals
 tupleToRefs whnf = return <$> newEvaluatedObjectRef whnf
 
 tupleToListWHNF :: WHNFData -> EvalM [WHNFData]
-tupleToListWHNF (Intermediate (ITuple refs)) = mapM evalRef refs
-tupleToListWHNF (Value (Tuple vals))         = return $ map Value vals
-tupleToListWHNF whnf                         = return [whnf]
+tupleToListWHNF (ITuple refs)        = mapM evalRef refs
+tupleToListWHNF (Value (Tuple vals)) = return $ map Value vals
+tupleToListWHNF whnf                 = return [whnf]
 
 tupleToList :: EgisonValue -> [EgisonValue]
 tupleToList (Tuple vals) = vals
@@ -66,6 +66,6 @@ makeTuple [x] = x
 makeTuple xs  = Tuple xs
 
 makeITuple :: [WHNFData] -> EvalM WHNFData
-makeITuple []  = return $ Intermediate (ITuple [])
+makeITuple []  = return (ITuple [])
 makeITuple [x] = return x
-makeITuple xs  = Intermediate . ITuple <$> mapM newEvaluatedObjectRef xs
+makeITuple xs  = ITuple <$> mapM newEvaluatedObjectRef xs

--- a/hs-src/Language/Egison/Primitives.hs
+++ b/hs-src/Language/Egison/Primitives.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase       #-}
-{-# LANGUAGE RankNTypes       #-}
 
 {- |
 Module      : Language.Egison.Primitives
@@ -18,20 +17,15 @@ import           Control.Monad.Except
 
 import           Data.Foldable             (toList)
 import           Data.IORef
-import           Data.Ratio
 import           Text.Regex.TDFA           ((=~~))
 
-import           System.IO
 import           System.Process            (readProcess)
-import           System.Random             (getStdRandom, randomR)
 
 import qualified Data.Sequence             as Sq
 import qualified Data.Vector               as V
 
-import           Data.Char                 (chr, ord)
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T
-import qualified Data.Text.IO              as T
 
  {--  -- for 'egison-sqlite'
 import qualified Database.SQLite3 as SQLite
@@ -43,9 +37,11 @@ import           Language.Egison.Eval
 import           Language.Egison.EvalState (MonadEval(..))
 import           Language.Egison.Parser
 import           Language.Egison.Pretty
+import           Language.Egison.Primitives.Arith
+import           Language.Egison.Primitives.IO
 import           Language.Egison.Primitives.Types
+import           Language.Egison.Primitives.Utils
 import           Language.Egison.Math
-import           Language.Egison.Tensor
 
 primitiveEnv :: IO Env
 primitiveEnv = do
@@ -63,67 +59,6 @@ primitiveEnvNoIO = do
     return (stringToVar name, ref)
   return $ extendEnv nullEnv bindings
 
-{-# INLINE noArg #-}
-noArg :: EvalM EgisonValue -> String -> PrimitiveFunc
-noArg f name args =
-  case args of
-    [] -> f
-    [Tuple []] -> f
-    _ ->
-      throwError =<< ArgumentsNumPrimitive name 1 (length args) <$> getFuncNameStack
-
-{-# INLINE oneArg #-}
-oneArg :: (EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
-oneArg f name args =
-  case args of
-    [TensorData (Tensor ns ds js)] -> do
-      ds' <- V.mapM f ds
-      fromTensor (Tensor ns ds' js)
-    [arg] -> f arg
-    _ ->
-      throwError =<< ArgumentsNumPrimitive name 1 (length args) <$> getFuncNameStack
-
-{-# INLINE oneArg' #-}
-oneArg' :: (EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
-oneArg' f name args =
-  case args of
-    [arg] -> f arg
-    _     -> 
-      throwError =<< ArgumentsNumPrimitive name 1 (length args) <$> getFuncNameStack
-
-{-# INLINE twoArgs #-}
-twoArgs :: (EgisonValue -> EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
-twoArgs f name args =
-  case args of
-    [TensorData t1@Tensor{}, TensorData t2@Tensor{}] ->
-      tProduct f t1 t2 >>= fromTensor
-    [TensorData(Tensor ns ds js), val] -> do
-      ds' <- V.mapM (`f` val) ds
-      fromTensor (Tensor ns ds' js)
-    [val, TensorData (Tensor ns ds js)] -> do
-      ds' <- V.mapM (f val) ds
-      fromTensor (Tensor ns ds' js)
-    [val, val'] -> f val val'
-    [val] -> return . PrimitiveFunc $ oneArg (f val) name
-    _ -> throwError =<< ArgumentsNumPrimitive name 2 (length args) <$> getFuncNameStack
-
-{-# INLINE twoArgs' #-}
-twoArgs' :: (EgisonValue -> EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
-twoArgs' f name args =
-  case args of
-    [val, val'] -> f val val'
-    [val]       -> return . PrimitiveFunc $ oneArg' (f val) name
-    _           -> throwError =<< ArgumentsNumPrimitive name 2 (length args) <$> getFuncNameStack
-
-{-# INLINE threeArgs' #-}
-threeArgs' :: (EgisonValue -> EgisonValue -> EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
-threeArgs' f name args =
-  case args of
-    [val, val', val''] -> f val val' val''
-    [val, val']        -> return . PrimitiveFunc $ oneArg' (f val val') name
-    [val]              -> return . PrimitiveFunc $ twoArgs' (f val) name
-    _                  -> throwError =<< ArgumentsNumPrimitive name 3 (length args) <$> getFuncNameStack
-
 --
 -- Constants
 --
@@ -139,62 +74,9 @@ constants = [ ("f.pi", Float 3.141592653589793)
 
 primitives :: [(String, String -> PrimitiveFunc)]
 primitives =
-  [ ("b.+", plus)
-  , ("b.-", minus)
-  , ("b.*", multiply)
-  , ("b./", divide)
-  , ("f.+", floatBinaryOp (+))
-  , ("f.-", floatBinaryOp (-))
-  , ("f.*", floatBinaryOp (*))
-  , ("f./", floatBinaryOp (/))
-  , ("numerator", numerator')
-  , ("denominator", denominator')
-  , ("fromMathExpr", fromScalarData)
-  , ("toMathExpr'", toScalarData)
-  , ("symbolNormalize", symbolNormalize)
-
-  , ("modulo",   integerBinaryOp mod)
-  , ("quotient", integerBinaryOp quot)
-  , ("%",        integerBinaryOp rem)
-  , ("b.abs", rationalUnaryOp abs)
-  , ("b.neg", rationalUnaryOp negate)
-
-  , ("=",  eq)
-  , ("<",  scalarCompare (<))
-  , ("<=", scalarCompare (<=))
-  , (">",  scalarCompare (>))
-  , (">=", scalarCompare (>=))
-
-  , ("round",    floatToIntegerOp round)
-  , ("floor",    floatToIntegerOp floor)
-  , ("ceiling",  floatToIntegerOp ceiling)
-  , ("truncate", truncate')
-
-  , ("b.sqrt",  floatUnaryOp sqrt)
-  , ("b.sqrt'", floatUnaryOp sqrt)
-  , ("b.exp",   floatUnaryOp exp)
-  , ("b.log",   floatUnaryOp log)
-  , ("b.sin",   floatUnaryOp sin)
-  , ("b.cos",   floatUnaryOp cos)
-  , ("b.tan",   floatUnaryOp tan)
-  , ("b.asin",  floatUnaryOp asin)
-  , ("b.acos",  floatUnaryOp acos)
-  , ("b.atan",  floatUnaryOp atan)
-  , ("b.sinh",  floatUnaryOp sinh)
-  , ("b.cosh",  floatUnaryOp cosh)
-  , ("b.tanh",  floatUnaryOp tanh)
-  , ("b.asinh", floatUnaryOp asinh)
-  , ("b.acosh", floatUnaryOp acosh)
-  , ("b.atanh", floatUnaryOp atanh)
-
-  , ("tensorShape", tensorShape')
+  [ ("tensorShape", tensorShape')
   , ("tensorToList", tensorToList')
   , ("dfOrder", dfOrder')
-
-  , ("itof", integerToFloat)
-  , ("rtof", rationalToFloat)
-  , ("ctoi", charToInteger)
-  , ("itoc", integerToChar)
 
   , ("pack", pack)
   , ("unpack", unpack)
@@ -216,113 +98,11 @@ primitives =
   , ("show", show')
   , ("showTsv", showTSV')
 
-  , ("assert", assert)
+  , ("assert",      assert)
   , ("assertEqual", assertEqual)
   ]
-  ++ map (\(name, fn) -> (name, oneArg' fn)) primitiveTypeFunctions
-
-
-unaryOp :: (EgisonData a, EgisonData b) => (a -> b) -> String -> PrimitiveFunc
-unaryOp op = oneArg $ \val -> do
-  v <- fromEgison val
-  return $ toEgison (op v)
-
-binaryOp :: (EgisonData a, EgisonData b) => (a -> a -> b) -> String -> PrimitiveFunc
-binaryOp op = twoArgs $ \val val' -> do
-  i <- fromEgison val
-  i' <- fromEgison val'
-  return $ toEgison (op i i')
-
-rationalUnaryOp :: (Rational -> Rational) -> String -> PrimitiveFunc
-rationalUnaryOp = unaryOp
-
-integerBinaryOp :: (Integer -> Integer -> Integer) -> String -> PrimitiveFunc
-integerBinaryOp = binaryOp
-
-floatUnaryOp :: (Double -> Double) -> String -> PrimitiveFunc
-floatUnaryOp = unaryOp
-
-floatBinaryOp :: (Double -> Double -> Double) -> String -> PrimitiveFunc
-floatBinaryOp = binaryOp
-
---
--- Arith
---
-
-scalarBinaryOp :: (ScalarData -> ScalarData -> ScalarData) -> String -> PrimitiveFunc
-scalarBinaryOp mOp = twoArgs scalarBinaryOp'
- where
-  scalarBinaryOp' (ScalarData m1) (ScalarData m2) = (return . ScalarData) (mOp m1 m2)
-  scalarBinaryOp' (ScalarData _)  val             = throwError =<< TypeMismatch "number" (Value val) <$> getFuncNameStack
-  scalarBinaryOp' val             _               = throwError =<< TypeMismatch "number" (Value val) <$> getFuncNameStack
-
-plus :: String -> PrimitiveFunc
-plus = scalarBinaryOp mathPlus
-
-minus :: String -> PrimitiveFunc
-minus = scalarBinaryOp (\m1 m2 -> mathPlus m1 (mathNegate m2))
-
-multiply :: String -> PrimitiveFunc
-multiply = scalarBinaryOp mathMult
-
-divide :: String -> PrimitiveFunc
-divide = scalarBinaryOp mathDiv
-
-numerator' :: String -> PrimitiveFunc
-numerator' = oneArg numerator''
- where
-  numerator'' (ScalarData m) = return $ ScalarData (mathNumerator m)
-  numerator'' val = throwError =<< TypeMismatch "rational" (Value val) <$> getFuncNameStack
-
-denominator' :: String -> PrimitiveFunc
-denominator' = oneArg denominator''
- where
-  denominator'' (ScalarData m) = return $ ScalarData (mathDenominator m)
-  denominator'' val = throwError =<< TypeMismatch "rational" (Value val) <$> getFuncNameStack
-
-fromScalarData :: String -> PrimitiveFunc
-fromScalarData = oneArg fromScalarData'
- where
-  fromScalarData' (ScalarData m) = return $ mathExprToEgison m
-  fromScalarData' val = throwError =<< TypeMismatch "number" (Value val) <$> getFuncNameStack
-
-toScalarData :: String -> PrimitiveFunc
-toScalarData = oneArg $ \val ->
-  ScalarData . mathNormalize' <$> egisonToScalarData val
-
-symbolNormalize :: String -> PrimitiveFunc
-symbolNormalize = oneArg $ \val ->
-  case val of
-    ScalarData s -> return $ ScalarData (rewriteSymbol s)
-    _ -> throwError =<< TypeMismatch "math expression" (Value val) <$> getFuncNameStack
-
-
---
--- Pred
---
-eq :: String -> PrimitiveFunc
-eq = twoArgs' $ \val val' ->
-  return $ Bool $ val == val'
-
-scalarCompare :: (forall a. Ord a => a -> a -> Bool) -> String -> PrimitiveFunc
-scalarCompare cmp = twoArgs' $ \val1 val2 ->
-  case (val1, val2) of
-    (ScalarData _, ScalarData _) -> do
-      r1 <- fromEgison val1 :: EvalM Rational
-      r2 <- fromEgison val2 :: EvalM Rational
-      return $ Bool (cmp r1 r2)
-    (Float f1, Float f2) -> return $ Bool (cmp f1 f2)
-    (ScalarData _, _) -> throwError =<< TypeMismatch "number" (Value val2) <$> getFuncNameStack
-    (Float _,      _) -> throwError =<< TypeMismatch "float"  (Value val2) <$> getFuncNameStack
-    _                 -> throwError =<< TypeMismatch "number" (Value val1) <$> getFuncNameStack
-
-truncate' :: String -> PrimitiveFunc
-truncate' = oneArg $ \val -> numberUnaryOp' val
- where
-  numberUnaryOp' (ScalarData (Div (Plus []) _)) = return $ toEgison (0 :: Integer)
-  numberUnaryOp' (ScalarData (Div (Plus [Term x []]) (Plus [Term y []]))) = return $ toEgison (quot x y)
-  numberUnaryOp' (Float x)             = return $ toEgison (truncate x :: Integer)
-  numberUnaryOp' val                   = throwError =<< TypeMismatch "rational or float" (Value val) <$> getFuncNameStack
+  ++ primitiveTypeFunctions
+  ++ primitiveArithFunctions
 
 --
 -- Tensor
@@ -345,34 +125,6 @@ dfOrder' = oneArg' dfOrder''
  where
   dfOrder'' (TensorData (Tensor ns _ is)) = return (toEgison (fromIntegral (length ns - length is) :: Integer))
   dfOrder'' _ = return (toEgison (0 :: Integer))
-
---
--- Transform
---
-integerToFloat :: String -> PrimitiveFunc
-integerToFloat = rationalToFloat
-
-rationalToFloat :: String -> PrimitiveFunc
-rationalToFloat = oneArg $ \val ->
-  case val of
-    ScalarData (Div (Plus []) _) -> return $ Float 0
-    ScalarData (Div (Plus [Term x []]) (Plus [Term y []])) -> return $ Float (fromRational (x % y))
-    _ -> throwError =<< TypeMismatch "integer or rational number" (Value val) <$> getFuncNameStack
-
-charToInteger :: String -> PrimitiveFunc
-charToInteger = unaryOp ctoi
-  where
-    ctoi :: Char -> Integer
-    ctoi = fromIntegral . ord
-
-integerToChar :: String -> PrimitiveFunc
-integerToChar = unaryOp itoc
-  where
-    itoc :: Integer -> Char
-    itoc = chr . fromIntegral
-
-floatToIntegerOp :: (Double -> Integer) -> String -> PrimitiveFunc
-floatToIntegerOp = unaryOp
 
 --
 -- String
@@ -428,13 +180,6 @@ regexStringCaptureGroup = twoArgs $ \pat src -> do
     Nothing -> return . Collection . Sq.fromList $ []
     Just ((x:xs):_) -> do let (a, c) = T.breakOn (T.pack x) srcStr
                           return . Collection . Sq.fromList $ [Tuple [String a, Collection (Sq.fromList (map (String . T.pack) xs)), String (T.drop (length x) c)]]
-
---regexStringMatch :: PrimitiveFunc
---regexStringMatch = twoArgs $ \pat src -> do
---  case (pat, src) of
---    (String patStr, String srcStr) -> return . Bool $ (((T.unpack srcStr) =~ (T.unpack patStr)) :: Bool)
---    (String _, _) -> throwError =<< TypeMismatch "string" (Value src) <$> getFuncNameStack
---    (_, _) -> throwError =<< TypeMismatch "string" (Value pat) <$> getFuncNameStack
 
 addPrime :: String -> PrimitiveFunc
 addPrime = oneArg $ \sym ->
@@ -510,155 +255,6 @@ assertEqual = threeArgs' $ \label actual expected ->
      then return $ Bool True
      else throwError =<< Assertion
        (show label ++ "\n expected: " ++ show expected ++ "\n but found: " ++ show actual) <$> getFuncNameStack
-
---
--- IO Primitives
---
-
-ioPrimitives :: [(String, String -> PrimitiveFunc)]
-ioPrimitives =
-  [ ("return", return')
-  , ("openInputFile", makePort ReadMode)
-  , ("openOutputFile", makePort WriteMode)
-  , ("closeInputPort", closePort)
-  , ("closeOutputPort", closePort)
-  , ("readChar", readChar)
-  , ("readLine", readLine)
-  , ("writeChar", writeChar)
-  , ("write", writeString)
-
-  , ("readCharFromPort", readCharFromPort)
-  , ("readLineFromPort", readLineFromPort)
-  , ("writeCharToPort", writeCharToPort)
-  , ("writeToPort", writeStringToPort)
-
-  , ("isEof", isEOFStdin)
-  , ("flush", flushStdout)
-  , ("isEofPort", isEOFPort)
-  , ("flushPort", flushPort)
-  , ("readFile", readFile')
-
-  , ("rand", randRange)
-  , ("f.rand", randRangeDouble)
-
-  , ("newIORef", newIORef')
-  , ("writeIORef", writeIORef')
-  , ("readIORef", readIORef')
-  ]
-
-makeIO :: EvalM EgisonValue -> EgisonValue
-makeIO m = IOFunc $ fmap (Value . Tuple . (World :) . (:[])) m
-
-makeIO' :: EvalM () -> EgisonValue
-makeIO' m = IOFunc $ m >> return (Value $ Tuple [World, Tuple []])
-
-return' :: String -> PrimitiveFunc
-return' = oneArg' $ \val -> return $ makeIO $ return val
-
-makePort :: IOMode -> String -> PrimitiveFunc
-makePort mode = oneArg' $ \val -> do
-  filename <- fromEgison val
-  port <- liftIO $ openFile (T.unpack filename) mode
-  return $ makeIO $ return (Port port)
-
-closePort :: String -> PrimitiveFunc
-closePort = oneArg' $ \val -> do
-  port <- fromEgison val
-  return $ makeIO' $ liftIO $ hClose port
-
-writeChar :: String -> PrimitiveFunc
-writeChar = oneArg' $ \val -> do
-  c <- fromEgison val
-  return $ makeIO' $ liftIO $ putChar c
-
-writeCharToPort :: String -> PrimitiveFunc
-writeCharToPort = twoArgs' $ \val val' -> do
-  port <- fromEgison val
-  c <- fromEgison val'
-  return $ makeIO' $ liftIO $ hPutChar port c
-
-writeString :: String -> PrimitiveFunc
-writeString = oneArg' $ \val -> do
-  s <- fromEgison val
-  return $ makeIO' $ liftIO $ T.putStr s
-
-writeStringToPort :: String -> PrimitiveFunc
-writeStringToPort = twoArgs' $ \val val' -> do
-  port <- fromEgison val
-  s <- fromEgison val'
-  return $ makeIO' $ liftIO $ T.hPutStr port s
-
-flushStdout :: String -> PrimitiveFunc
-flushStdout = noArg $ return $ makeIO' $ liftIO $ hFlush stdout
-
-flushPort :: String -> PrimitiveFunc
-flushPort = oneArg' $ \val -> do
-  port <- fromEgison val
-  return $ makeIO' $ liftIO $ hFlush port
-
-readChar :: String -> PrimitiveFunc
-readChar = noArg $ return $ makeIO $ liftIO $ fmap Char getChar
-
-readCharFromPort :: String -> PrimitiveFunc
-readCharFromPort = oneArg' $ \val -> do
-  port <- fromEgison val
-  c <- liftIO $ hGetChar port
-  return $ makeIO $ return (Char c)
-
-readLine :: String -> PrimitiveFunc
-readLine = noArg $ return $ makeIO $ liftIO $ fmap toEgison T.getLine
-
-readLineFromPort :: String -> PrimitiveFunc
-readLineFromPort = oneArg' $ \val -> do
-  port <- fromEgison val
-  s <- liftIO $ T.hGetLine port
-  return $ makeIO $ return $ toEgison s
-
-readFile' :: String -> PrimitiveFunc
-readFile' =  oneArg' $ \val -> do
-  filename <- fromEgison val
-  s <- liftIO $ T.readFile $ T.unpack filename
-  return $ makeIO $ return $ toEgison s
-
-isEOFStdin :: String -> PrimitiveFunc
-isEOFStdin = noArg $ return $ makeIO $ liftIO $ fmap Bool isEOF
-
-isEOFPort :: String -> PrimitiveFunc
-isEOFPort = oneArg' $ \val -> do
-  port <- fromEgison val
-  b <- liftIO $ hIsEOF port
-  return $ makeIO $ return (Bool b)
-
-randRange :: String -> PrimitiveFunc
-randRange = twoArgs' $ \val val' -> do
-  i <- fromEgison val :: EvalM Integer
-  i' <- fromEgison val' :: EvalM Integer
-  n <- liftIO $ getStdRandom $ randomR (i, i')
-  return $ makeIO $ return $ toEgison n
-
-randRangeDouble :: String -> PrimitiveFunc
-randRangeDouble = twoArgs' $ \val val' -> do
-  i <- fromEgison val :: EvalM Double
-  i' <- fromEgison val' :: EvalM Double
-  n <- liftIO $ getStdRandom $ randomR (i, i')
-  return $ makeIO $ return $ toEgison n
-
-newIORef' :: String -> PrimitiveFunc
-newIORef' = noArg $ do
-  ref <- liftIO $ newIORef Undefined
-  return $ makeIO $ return (RefBox ref)
-
-writeIORef' :: String -> PrimitiveFunc
-writeIORef' = twoArgs $ \ref val -> do
-  ref' <- fromEgison ref
-  return $ makeIO' $ liftIO $ writeIORef ref' val
-
-readIORef' :: String -> PrimitiveFunc
-readIORef' = oneArg $ \ref -> do
-  ref' <- fromEgison ref
-  val <- liftIO $ readIORef ref'
-  return $ makeIO $ return val
-
 
  {-- -- for 'egison-sqlite'
 sqlite :: PrimitiveFunc

--- a/hs-src/Language/Egison/Primitives/Arith.hs
+++ b/hs-src/Language/Egison/Primitives/Arith.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes       #-}
+
+module Language.Egison.Primitives.Arith
+  ( primitiveArithFunctions
+  ) where
+
+import           Control.Monad.Except
+import           Language.Egison.Data
+import           Language.Egison.EvalState (MonadEval(..))
+import           Language.Egison.Primitives.Utils
+import           Language.Egison.Math
+
+primitiveArithFunctions :: [(String, String -> PrimitiveFunc)]
+primitiveArithFunctions =
+  [ ("b.+", plus)
+  , ("b.-", minus)
+  , ("b.*", multiply)
+  , ("b./", divide)
+  , ("f.+", floatBinaryOp (+))
+  , ("f.-", floatBinaryOp (-))
+  , ("f.*", floatBinaryOp (*))
+  , ("f./", floatBinaryOp (/))
+  , ("numerator",       numerator')
+  , ("denominator",     denominator')
+  , ("fromMathExpr",    fromScalarData)
+  , ("toMathExpr'",     toScalarData)
+  , ("symbolNormalize", symbolNormalize)
+
+  , ("modulo",   integerBinaryOp mod)
+  , ("quotient", integerBinaryOp quot)
+  , ("%",        integerBinaryOp rem)
+  , ("b.abs",    rationalUnaryOp abs)
+  , ("b.neg",    rationalUnaryOp negate)
+
+  , ("=",  eq)
+  , ("<",  scalarCompare (<))
+  , ("<=", scalarCompare (<=))
+  , (">",  scalarCompare (>))
+  , (">=", scalarCompare (>=))
+
+  , ("round",    floatToIntegerOp round)
+  , ("floor",    floatToIntegerOp floor)
+  , ("ceiling",  floatToIntegerOp ceiling)
+  , ("truncate", truncate')
+
+  , ("b.sqrt",  floatUnaryOp sqrt)
+  , ("b.sqrt'", floatUnaryOp sqrt)
+  , ("b.exp",   floatUnaryOp exp)
+  , ("b.log",   floatUnaryOp log)
+  , ("b.sin",   floatUnaryOp sin)
+  , ("b.cos",   floatUnaryOp cos)
+  , ("b.tan",   floatUnaryOp tan)
+  , ("b.asin",  floatUnaryOp asin)
+  , ("b.acos",  floatUnaryOp acos)
+  , ("b.atan",  floatUnaryOp atan)
+  , ("b.sinh",  floatUnaryOp sinh)
+  , ("b.cosh",  floatUnaryOp cosh)
+  , ("b.tanh",  floatUnaryOp tanh)
+  , ("b.asinh", floatUnaryOp asinh)
+  , ("b.acosh", floatUnaryOp acosh)
+  , ("b.atanh", floatUnaryOp atanh)
+  ]
+
+
+rationalUnaryOp :: (Rational -> Rational) -> String -> PrimitiveFunc
+rationalUnaryOp = unaryOp
+
+integerBinaryOp :: (Integer -> Integer -> Integer) -> String -> PrimitiveFunc
+integerBinaryOp = binaryOp
+
+floatUnaryOp :: (Double -> Double) -> String -> PrimitiveFunc
+floatUnaryOp = unaryOp
+
+floatBinaryOp :: (Double -> Double -> Double) -> String -> PrimitiveFunc
+floatBinaryOp = binaryOp
+
+floatToIntegerOp :: (Double -> Integer) -> String -> PrimitiveFunc
+floatToIntegerOp = unaryOp
+
+--
+-- Arith
+--
+scalarBinaryOp :: (ScalarData -> ScalarData -> ScalarData) -> String -> PrimitiveFunc
+scalarBinaryOp mOp = twoArgs scalarBinaryOp'
+ where
+  scalarBinaryOp' (ScalarData m1) (ScalarData m2) = (return . ScalarData) (mOp m1 m2)
+  scalarBinaryOp' (ScalarData _)  val             = throwError =<< TypeMismatch "number" (Value val) <$> getFuncNameStack
+  scalarBinaryOp' val             _               = throwError =<< TypeMismatch "number" (Value val) <$> getFuncNameStack
+
+plus :: String -> PrimitiveFunc
+plus = scalarBinaryOp mathPlus
+
+minus :: String -> PrimitiveFunc
+minus = scalarBinaryOp (\m1 m2 -> mathPlus m1 (mathNegate m2))
+
+multiply :: String -> PrimitiveFunc
+multiply = scalarBinaryOp mathMult
+
+divide :: String -> PrimitiveFunc
+divide = scalarBinaryOp mathDiv
+
+numerator' :: String -> PrimitiveFunc
+numerator' = oneArg numerator''
+ where
+  numerator'' (ScalarData m) = return $ ScalarData (mathNumerator m)
+  numerator'' val = throwError =<< TypeMismatch "rational" (Value val) <$> getFuncNameStack
+
+denominator' :: String -> PrimitiveFunc
+denominator' = oneArg denominator''
+ where
+  denominator'' (ScalarData m) = return $ ScalarData (mathDenominator m)
+  denominator'' val = throwError =<< TypeMismatch "rational" (Value val) <$> getFuncNameStack
+
+fromScalarData :: String -> PrimitiveFunc
+fromScalarData = oneArg fromScalarData'
+ where
+  fromScalarData' (ScalarData m) = return $ mathExprToEgison m
+  fromScalarData' val = throwError =<< TypeMismatch "number" (Value val) <$> getFuncNameStack
+
+toScalarData :: String -> PrimitiveFunc
+toScalarData = oneArg $ \val ->
+  ScalarData . mathNormalize' <$> egisonToScalarData val
+
+symbolNormalize :: String -> PrimitiveFunc
+symbolNormalize = oneArg $ \val ->
+  case val of
+    ScalarData s -> return $ ScalarData (rewriteSymbol s)
+    _ -> throwError =<< TypeMismatch "math expression" (Value val) <$> getFuncNameStack
+
+--
+-- Pred
+--
+eq :: String -> PrimitiveFunc
+eq = twoArgs' $ \val val' ->
+  return $ Bool $ val == val'
+
+scalarCompare :: (forall a. Ord a => a -> a -> Bool) -> String -> PrimitiveFunc
+scalarCompare cmp = twoArgs' $ \val1 val2 ->
+  case (val1, val2) of
+    (ScalarData _, ScalarData _) -> do
+      r1 <- fromEgison val1 :: EvalM Rational
+      r2 <- fromEgison val2 :: EvalM Rational
+      return $ Bool (cmp r1 r2)
+    (Float f1, Float f2) -> return $ Bool (cmp f1 f2)
+    (ScalarData _, _) -> throwError =<< TypeMismatch "number" (Value val2) <$> getFuncNameStack
+    (Float _,      _) -> throwError =<< TypeMismatch "float"  (Value val2) <$> getFuncNameStack
+    _                 -> throwError =<< TypeMismatch "number" (Value val1) <$> getFuncNameStack
+
+truncate' :: String -> PrimitiveFunc
+truncate' = oneArg $ \val -> numberUnaryOp' val
+ where
+  numberUnaryOp' (ScalarData (Div (Plus []) _)) = return $ toEgison (0 :: Integer)
+  numberUnaryOp' (ScalarData (Div (Plus [Term x []]) (Plus [Term y []]))) = return $ toEgison (quot x y)
+  numberUnaryOp' (Float x)             = return $ toEgison (truncate x :: Integer)
+  numberUnaryOp' val                   = throwError =<< TypeMismatch "rational or float" (Value val) <$> getFuncNameStack

--- a/hs-src/Language/Egison/Primitives/IO.hs
+++ b/hs-src/Language/Egison/Primitives/IO.hs
@@ -1,0 +1,165 @@
+module Language.Egison.Primitives.IO
+  ( ioPrimitives
+  ) where
+
+import           Control.Monad.Except
+
+import           Data.IORef
+
+import           System.IO
+import           System.Random             (getStdRandom, randomR)
+
+import qualified Data.Text                 as T
+import qualified Data.Text.IO              as T
+
+import           Language.Egison.Data
+import           Language.Egison.Primitives.Utils
+
+
+--
+-- IO Primitives
+--
+
+ioPrimitives :: [(String, String -> PrimitiveFunc)]
+ioPrimitives =
+  [ ("return",          return')
+  , ("openInputFile",   makePort ReadMode)
+  , ("openOutputFile",  makePort WriteMode)
+  , ("closeInputPort",  closePort)
+  , ("closeOutputPort", closePort)
+  , ("readChar",        readChar)
+  , ("readLine",        readLine)
+  , ("writeChar",       writeChar)
+  , ("write",           writeString)
+
+  , ("readCharFromPort", readCharFromPort)
+  , ("readLineFromPort", readLineFromPort)
+  , ("writeCharToPort",  writeCharToPort)
+  , ("writeToPort",      writeStringToPort)
+
+  , ("isEof",     isEOFStdin)
+  , ("flush",     flushStdout)
+  , ("isEofPort", isEOFPort)
+  , ("flushPort", flushPort)
+  , ("readFile",  readFile')
+
+  , ("rand",       randRange)
+  , ("f.rand",     randRangeDouble)
+
+  , ("newIORef",   newIORef')
+  , ("writeIORef", writeIORef')
+  , ("readIORef",  readIORef')
+  ]
+
+makeIO :: EvalM EgisonValue -> EgisonValue
+makeIO m = IOFunc $ fmap (Value . Tuple . (World :) . (:[])) m
+
+makeIO' :: EvalM () -> EgisonValue
+makeIO' m = IOFunc $ m >> return (Value $ Tuple [World, Tuple []])
+
+return' :: String -> PrimitiveFunc
+return' = oneArg' $ \val -> return $ makeIO $ return val
+
+makePort :: IOMode -> String -> PrimitiveFunc
+makePort mode = oneArg' $ \val -> do
+  filename <- fromEgison val
+  port <- liftIO $ openFile (T.unpack filename) mode
+  return $ makeIO $ return (Port port)
+
+closePort :: String -> PrimitiveFunc
+closePort = oneArg' $ \val -> do
+  port <- fromEgison val
+  return $ makeIO' $ liftIO $ hClose port
+
+writeChar :: String -> PrimitiveFunc
+writeChar = oneArg' $ \val -> do
+  c <- fromEgison val
+  return $ makeIO' $ liftIO $ putChar c
+
+writeCharToPort :: String -> PrimitiveFunc
+writeCharToPort = twoArgs' $ \val val' -> do
+  port <- fromEgison val
+  c <- fromEgison val'
+  return $ makeIO' $ liftIO $ hPutChar port c
+
+writeString :: String -> PrimitiveFunc
+writeString = oneArg' $ \val -> do
+  s <- fromEgison val
+  return $ makeIO' $ liftIO $ T.putStr s
+
+writeStringToPort :: String -> PrimitiveFunc
+writeStringToPort = twoArgs' $ \val val' -> do
+  port <- fromEgison val
+  s <- fromEgison val'
+  return $ makeIO' $ liftIO $ T.hPutStr port s
+
+flushStdout :: String -> PrimitiveFunc
+flushStdout = noArg $ return $ makeIO' $ liftIO $ hFlush stdout
+
+flushPort :: String -> PrimitiveFunc
+flushPort = oneArg' $ \val -> do
+  port <- fromEgison val
+  return $ makeIO' $ liftIO $ hFlush port
+
+readChar :: String -> PrimitiveFunc
+readChar = noArg $ return $ makeIO $ liftIO $ fmap Char getChar
+
+readCharFromPort :: String -> PrimitiveFunc
+readCharFromPort = oneArg' $ \val -> do
+  port <- fromEgison val
+  c <- liftIO $ hGetChar port
+  return $ makeIO $ return (Char c)
+
+readLine :: String -> PrimitiveFunc
+readLine = noArg $ return $ makeIO $ liftIO $ fmap toEgison T.getLine
+
+readLineFromPort :: String -> PrimitiveFunc
+readLineFromPort = oneArg' $ \val -> do
+  port <- fromEgison val
+  s <- liftIO $ T.hGetLine port
+  return $ makeIO $ return $ toEgison s
+
+readFile' :: String -> PrimitiveFunc
+readFile' =  oneArg' $ \val -> do
+  filename <- fromEgison val
+  s <- liftIO $ T.readFile $ T.unpack filename
+  return $ makeIO $ return $ toEgison s
+
+isEOFStdin :: String -> PrimitiveFunc
+isEOFStdin = noArg $ return $ makeIO $ liftIO $ fmap Bool isEOF
+
+isEOFPort :: String -> PrimitiveFunc
+isEOFPort = oneArg' $ \val -> do
+  port <- fromEgison val
+  b <- liftIO $ hIsEOF port
+  return $ makeIO $ return (Bool b)
+
+randRange :: String -> PrimitiveFunc
+randRange = twoArgs' $ \val val' -> do
+  i <- fromEgison val :: EvalM Integer
+  i' <- fromEgison val' :: EvalM Integer
+  n <- liftIO $ getStdRandom $ randomR (i, i')
+  return $ makeIO $ return $ toEgison n
+
+randRangeDouble :: String -> PrimitiveFunc
+randRangeDouble = twoArgs' $ \val val' -> do
+  i <- fromEgison val :: EvalM Double
+  i' <- fromEgison val' :: EvalM Double
+  n <- liftIO $ getStdRandom $ randomR (i, i')
+  return $ makeIO $ return $ toEgison n
+
+newIORef' :: String -> PrimitiveFunc
+newIORef' = noArg $ do
+  ref <- liftIO $ newIORef Undefined
+  return $ makeIO $ return (RefBox ref)
+
+writeIORef' :: String -> PrimitiveFunc
+writeIORef' = twoArgs $ \ref val -> do
+  ref' <- fromEgison ref
+  return $ makeIO' $ liftIO $ writeIORef ref' val
+
+readIORef' :: String -> PrimitiveFunc
+readIORef' = oneArg $ \ref -> do
+  ref' <- fromEgison ref
+  val <- liftIO $ readIORef ref'
+  return $ makeIO $ return val

--- a/hs-src/Language/Egison/Primitives/Utils.hs
+++ b/hs-src/Language/Egison/Primitives/Utils.hs
@@ -1,0 +1,90 @@
+module Language.Egison.Primitives.Utils
+  ( noArg
+  , oneArg
+  , oneArg'
+  , twoArgs
+  , twoArgs'
+  , threeArgs'
+  , unaryOp
+  , binaryOp
+  ) where
+
+import           Control.Monad.Except
+
+import qualified Data.Vector               as V
+
+import           Language.Egison.Data
+import           Language.Egison.EvalState (MonadEval(..))
+import           Language.Egison.Tensor
+
+{-# INLINE noArg #-}
+noArg :: EvalM EgisonValue -> String -> PrimitiveFunc
+noArg f name args =
+  case args of
+    [] -> f
+    [Tuple []] -> f
+    _ ->
+      throwError =<< ArgumentsNumPrimitive name 1 (length args) <$> getFuncNameStack
+
+{-# INLINE oneArg #-}
+oneArg :: (EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
+oneArg f name args =
+  case args of
+    [TensorData (Tensor ns ds js)] -> do
+      ds' <- V.mapM f ds
+      fromTensor (Tensor ns ds' js)
+    [arg] -> f arg
+    _ ->
+      throwError =<< ArgumentsNumPrimitive name 1 (length args) <$> getFuncNameStack
+
+{-# INLINE oneArg' #-}
+oneArg' :: (EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
+oneArg' f name args =
+  case args of
+    [arg] -> f arg
+    _     -> 
+      throwError =<< ArgumentsNumPrimitive name 1 (length args) <$> getFuncNameStack
+
+{-# INLINE twoArgs #-}
+twoArgs :: (EgisonValue -> EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
+twoArgs f name args =
+  case args of
+    [TensorData t1@Tensor{}, TensorData t2@Tensor{}] ->
+      tProduct f t1 t2 >>= fromTensor
+    [TensorData(Tensor ns ds js), val] -> do
+      ds' <- V.mapM (`f` val) ds
+      fromTensor (Tensor ns ds' js)
+    [val, TensorData (Tensor ns ds js)] -> do
+      ds' <- V.mapM (f val) ds
+      fromTensor (Tensor ns ds' js)
+    [val, val'] -> f val val'
+    [val] -> return . PrimitiveFunc $ oneArg (f val) name
+    _ -> throwError =<< ArgumentsNumPrimitive name 2 (length args) <$> getFuncNameStack
+
+{-# INLINE twoArgs' #-}
+twoArgs' :: (EgisonValue -> EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
+twoArgs' f name args =
+  case args of
+    [val, val'] -> f val val'
+    [val]       -> return . PrimitiveFunc $ oneArg' (f val) name
+    _           -> throwError =<< ArgumentsNumPrimitive name 2 (length args) <$> getFuncNameStack
+
+{-# INLINE threeArgs' #-}
+threeArgs' :: (EgisonValue -> EgisonValue -> EgisonValue -> EvalM EgisonValue) -> String -> PrimitiveFunc
+threeArgs' f name args =
+  case args of
+    [val, val', val''] -> f val val' val''
+    [val, val']        -> return . PrimitiveFunc $ oneArg' (f val val') name
+    [val]              -> return . PrimitiveFunc $ twoArgs' (f val) name
+    _                  -> throwError =<< ArgumentsNumPrimitive name 3 (length args) <$> getFuncNameStack
+
+unaryOp :: (EgisonData a, EgisonData b) => (a -> b) -> String -> PrimitiveFunc
+unaryOp op = oneArg $ \val -> do
+  v <- fromEgison val
+  return $ toEgison (op v)
+
+binaryOp :: (EgisonData a, EgisonData b) => (a -> a -> b) -> String -> PrimitiveFunc
+binaryOp op = twoArgs $ \val val' -> do
+  i <- fromEgison val
+  i' <- fromEgison val'
+  return $ toEgison (op i i')

--- a/hs-src/Language/Egison/Tensor.hs
+++ b/hs-src/Language/Egison/Tensor.hs
@@ -196,19 +196,19 @@ tFlipIndices :: HasTensor a => Tensor a -> EvalM (Tensor a)
 tFlipIndices (Tensor ns xs js) = return $ Tensor ns xs (map reverseIndex js)
 
 appendDFscripts :: Integer -> WHNFData -> WHNFData
-appendDFscripts id (Intermediate (ITensor (Tensor s xs is))) =
+appendDFscripts id (ITensor (Tensor s xs is)) =
   let k = fromIntegral (length s - length is)
-   in Intermediate (ITensor (Tensor s xs (is ++ map (DFscript id) [1..k])))
+   in ITensor (Tensor s xs (is ++ map (DFscript id) [1..k]))
 appendDFscripts id (Value (TensorData (Tensor s xs is))) =
   let k = fromIntegral (length s - length is)
    in Value (TensorData (Tensor s xs (is ++ map (DFscript id) [1..k])))
 appendDFscripts _ whnf = whnf
 
 removeDFscripts :: WHNFData -> EvalM WHNFData
-removeDFscripts (Intermediate (ITensor (Tensor s xs is))) = do
+removeDFscripts (ITensor (Tensor s xs is)) = do
   let (ds, js) = partition isDF is
   Tensor s ys _ <- tTranspose (js ++ ds) (Tensor s xs is)
-  return (Intermediate (ITensor (Tensor s ys js)))
+  return (ITensor (Tensor s ys js))
  where
   isDF (DFscript _ _) = True
   isDF _              = False
@@ -388,8 +388,8 @@ tConcat' ts = do
 --
 
 tensorToWHNF :: Tensor WHNFData -> WHNFData
-tensorToWHNF (Scalar whnf) = whnf
-tensorToWHNF t@(Tensor _ _ _) = Intermediate (ITensor t)
+tensorToWHNF (Scalar whnf)    = whnf
+tensorToWHNF t@(Tensor _ _ _) = ITensor t
 
 tensorToValue :: Tensor EgisonValue -> EgisonValue
 tensorToValue (Scalar val) = val


### PR DESCRIPTION
Egison should not throw exception when given too many arguments but rather repeat the application as follows.
```
fst (\x -> x + 2, 1) 3
-- 5
```