### PR TITLE
Pack arguments to \match and \matchAll in a tuple

### DIFF
--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -598,7 +598,7 @@ applyRef _ (Value (TFunc env name body)) refs = do
   tuple <- liftIO . newIORef $ WHNF $ ITuple refs
   evalExprShallow (extendEnv env $ makeBindings' [name] [tuple]) body
 applyRef _ (Value (PrimitiveFunc func)) refs = do
-  vals <- mapM (\ref -> evalRef ref >>= evalWHNF) refs
+  vals <- mapM evalRefDeep refs
   Value <$> func vals
 applyRef _ (Value (IOFunc m)) refs = do
   args <- mapM evalRef refs

--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -594,6 +594,8 @@ applyRef _ (Value (CFunc env name body)) refs = do
   seqRef <- liftIO . newIORef $ Sq.fromList (map IElement refs)
   col <- liftIO . newIORef $ WHNF $ ICollection seqRef
   evalExprShallow (extendEnv env $ makeBindings' [name] [col]) body
+applyRef _ (Value (TFunc env name body)) [ref] =
+  evalExprShallow (extendEnv env $ makeBindings' [name] [ref]) body
 applyRef _ (Value (TFunc env name body)) refs = do
   tuple <- liftIO . newIORef $ WHNF $ ITuple refs
   evalExprShallow (extendEnv env $ makeBindings' [name] [tuple]) body

--- a/hs-src/Language/Egison/Data.hs
+++ b/hs-src/Language/Egison/Data.hs
@@ -94,6 +94,7 @@ data EgisonValue
   | UserMatcher Env [IPatternDef]
   | Func (Maybe String) Env [String] IExpr
   | CFunc Env String IExpr
+  | TFunc Env String IExpr
   | MemoizedFunc (IORef (HashMap [Integer] WHNFData)) Env [String] IExpr
   | PatternFunc Env [String] IPattern
   | PrimitiveFunc PrimitiveFunc
@@ -263,6 +264,7 @@ instance Show EgisonValue where
   show UserMatcher{} = "#<user-matcher>"
   show (Func _ _ args _) = "#<lambda [" ++ intercalate ", " (map show args) ++ "] ...>"
   show (CFunc _ name _) = "#<cambda " ++ name ++ " ...>"
+  show (TFunc _ name _) = "#<tambda " ++ name ++ " ...>"
   show (MemoizedFunc _ _ names _) = "#<memoized-lambda [" ++ intercalate ", " names ++ "] ...>"
   show PatternFunc{} = "#<pattern-function>"
   show PrimitiveFunc{} = "#<primitive-function>"

--- a/hs-src/Language/Egison/Desugar.hs
+++ b/hs-src/Language/Egison/Desugar.hs
@@ -134,12 +134,12 @@ desugar (AlgebraicDataMatcherExpr patterns) = do
 
 desugar (MatchAllLambdaExpr matcher clauses) = do
   name <- fresh
-  ILambdaExpr Nothing [name] <$>
+  ITambdaExpr name <$>
     desugar (MatchAllExpr BFSMode (VarExpr name) matcher clauses)
 
 desugar (MatchLambdaExpr matcher clauses) = do
   name <- fresh
-  ILambdaExpr Nothing [name] <$>
+  ITambdaExpr name <$>
     desugar (MatchExpr BFSMode (VarExpr name) matcher clauses)
 
 -- TODO: Allow nested MultiSubscript and MultiSuperscript

--- a/hs-src/Language/Egison/IExpr.hs
+++ b/hs-src/Language/Egison/IExpr.hs
@@ -65,6 +65,7 @@ data IExpr
   | ILambdaExpr (Maybe String) [String] IExpr
   | IMemoizedLambdaExpr [String] IExpr
   | ICambdaExpr String IExpr
+  | ITambdaExpr String IExpr
   | IPatternFunctionExpr [String] IPattern
   | IIfExpr IExpr IExpr IExpr
   | ILetRecExpr [IBindingExpr] IExpr


### PR DESCRIPTION
* Added `ITambdaExpr` to `IExpr`, which is a tuple version of `ICambdaExpr`.
* Desugar `\match` and `\matchAll` into a `ITambdaExpr`.