### PR TITLE
Allow some primitive functions to lazily evaluate their arguments

### DIFF
--- a/hs-src/Language/Egison/Core.hs
+++ b/hs-src/Language/Egison/Core.hs
@@ -586,6 +586,9 @@ applyRef _ (Value (CFunc env name body)) refs = do
 applyRef _ (Value (PrimitiveFunc func)) refs = do
   vals <- mapM (\ref -> evalRef ref >>= evalWHNF) refs
   Value <$> func vals
+applyRef _ (Value (LazyPrimitiveFunc func)) refs = do
+  whnfs <- mapM evalRef refs
+  func whnfs
 applyRef _ (Value (IOFunc m)) refs = do
   args <- mapM evalRef refs
   case args of

--- a/hs-src/Language/Egison/Data.hs
+++ b/hs-src/Language/Egison/Data.hs
@@ -16,6 +16,7 @@ module Language.Egison.Data
       EgisonValue (..)
     , Matcher
     , PrimitiveFunc
+    , LazyPrimitiveFunc
     , EgisonHashKey (..)
     , EgisonData (..)
     , Tensor (..)
@@ -97,6 +98,7 @@ data EgisonValue
   | MemoizedFunc (IORef (HashMap [Integer] WHNFData)) Env [String] IExpr
   | PatternFunc Env [String] IPattern
   | PrimitiveFunc PrimitiveFunc
+  | LazyPrimitiveFunc LazyPrimitiveFunc
   | IOFunc (EvalM WHNFData)
   | Port Handle
   | RefBox (IORef EgisonValue)
@@ -106,6 +108,7 @@ data EgisonValue
 type Matcher = EgisonValue
 
 type PrimitiveFunc = [EgisonValue] -> EvalM EgisonValue
+type LazyPrimitiveFunc = [WHNFData] -> EvalM WHNFData
 
 data EgisonHashKey
   = IntKey Integer
@@ -266,6 +269,7 @@ instance Show EgisonValue where
   show (MemoizedFunc _ _ names _) = "#<memoized-lambda [" ++ intercalate ", " names ++ "] ...>"
   show PatternFunc{} = "#<pattern-function>"
   show PrimitiveFunc{} = "#<primitive-function>"
+  show LazyPrimitiveFunc{} = "#<primitive-function>"
   show IOFunc{} = "#<io-function>"
   show Port{}   = "#<port>"
   show RefBox{} = "#<refbox>"


### PR DESCRIPTION
Closes #238

This speeds up the evaluation of symmetric tensors a little, as follows:
```
-- previously 4.96 sec, now 3.84 sec
def T{_i_j} := generateTensor (\i j -> coefficient ((x + 1)^100) x 50) [2, 2]
T_#_#
```