### PR TITLE
Add test for executing main function

### DIFF
--- a/egison.cabal
+++ b/egison.cabal
@@ -61,8 +61,6 @@ Extra-Source-Files:  benchmark/Benchmark.hs
 
 Data-files:          lib/core/shell.egi
                      lib/core/*.egi lib/math/*.egi lib/math/common/*.egi lib/math/algebra/*.egi lib/math/analysis/*.egi lib/math/geometry/*.egi
-                     sample/*.egi sample/sat/*.egi sample/math/geometry/*.egi sample/math/number/*.egi
-                     test/*.egi test/lib/core/*.egi test/lib/math/*.egi
                      elisp/egison-mode.el
 
 

--- a/test/OptionsTest.hs
+++ b/test/OptionsTest.hs
@@ -59,6 +59,10 @@ main = defaultMain . hUnitTestToTests . test $ TestList
         (interpreter "3\n")
         ["--sexpr-syntax"]
         "(+ 1 2)"
+    , TestLabel "execute main function" . TestCase $ assertEgisonCmd
+        "[\"a\", \"b\", \"c\"]\n"
+        ["test/fixture/c.egi", "a", "b", "c"]
+        ""
     ]
 
 assertEgisonCmd

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -7,9 +7,7 @@ import           Test.Framework.Providers.HUnit (hUnitTestToTests)
 import           Test.HUnit
 
 import           Language.Egison
-import           Language.Egison.Eval
 import           Language.Egison.MathOutput
-import           Language.Egison.Parser
 
 main :: IO ()
 main = do

--- a/test/fixture/c.egi
+++ b/test/fixture/c.egi
@@ -1,0 +1,2 @@
+def main args :=
+  print (show args)


### PR DESCRIPTION
This PR adds a test for executing `main` function (with some command line arguments) when no option is passed to the interpreter.