### PR TITLE
Add `def` keyword to sample code in docs

### DIFF
--- a/docs/reference/basic-syntax.rst
+++ b/docs/reference/basic-syntax.rst
@@ -15,11 +15,11 @@ When defining functions, the argument variable can be placed in the left hand si
 
 ::
 
-   x := 1
+   def x := 1
 
    -- The following two definitions are identical.
-   f := \x -> x + 1
-   f x := x + 1
+   def f := \x -> x + 1
+   def f x := x + 1
 
 Expression
 ----------
@@ -30,8 +30,8 @@ These expressions are evaluated only when the ``-t`` option (see :ref:`command-o
 ::
 
    -- definitions
-   x := 1
-   y := 2
+   def x := 1
+   def y := 2
 
    -- A top-level expression which will evaluate to 3.
    x + y
@@ -67,14 +67,14 @@ In Egison, infix declaration consists of the following 4 parts.
    infixr expression 5 &&
 
    -- Definition of the semantics of '&&'.
-   (&&) a b := match (a, b) as (eq, eq) with
+   def (&&) a b := match (a, b) as (eq, eq) with
                  | (#True, #True) -> True
                  | _              -> False
 
    -- Define a left-associative infix '<>' of priority 7.
    infixl pattern 7 <>
 
-   exampleMatcher := matcher
+   def exampleMatcher := matcher
      | $ <> $ as (integer, integer) with
        | $x :: $y :: [] -> [(x, y)]
        | _              -> []
@@ -243,7 +243,7 @@ Note that all the lines in the ``do`` block must be aligned vertically.
 
 ::
 
-   repl := do
+   def repl := do
      write ">>> "
      flush ()
      let line := readLine ()
@@ -278,7 +278,7 @@ The most popular use case of seq is in the definition of the foldl function.
 
 ::
 
-   foldl $fn $init $ls :=
+   def foldl $fn $init $ls :=
      match ls as list something with
        | [] -> init
        | $x :: $xs ->

--- a/docs/reference/basic-syntax.rst
+++ b/docs/reference/basic-syntax.rst
@@ -191,7 +191,7 @@ As a result, note the following behavior.
 
 ::
 
-   x := 3
+   def x := 3
 
    let y := x
        x := 1

--- a/docs/reference/builtin-data.rst
+++ b/docs/reference/builtin-data.rst
@@ -156,7 +156,7 @@ The :math:`i`-th element of a tensor ``t`` can be retrieved by ``t_i``. Note tha
 
 ::
 
-   t := [| 1, 2, 3, 4, 5 |]
+   def t := [| 1, 2, 3, 4, 5 |]
 
    t_1 ---> 1
 

--- a/docs/reference/command-line-options.rst
+++ b/docs/reference/command-line-options.rst
@@ -9,7 +9,7 @@ Load definitions from the given file.
 ::
 
    $ cat name-of-file-to-load.egi
-   x := 1
+   def x := 1
 
    $ egison -l name-of-file-to-load.egi
    > x
@@ -25,7 +25,7 @@ Evaluate expressions in the given file.
 ::
 
    $ cat name-of-file-to-test.egi
-   x := 1
+   def x := 1
    x + 2
    "This is the third line"
 

--- a/docs/reference/pattern-matching.rst
+++ b/docs/reference/pattern-matching.rst
@@ -122,7 +122,7 @@ The application of pattern functions is written in the same manner as the applic
 ::
 
    -- Defining a pattern function 'twin'
-   twin := \ pat1 pat2 => ($pat & ~pat1) :: #pat :: ~pat2
+   def twin := \ pat1 pat2 => ($pat & ~pat1) :: #pat :: ~pat2
 
    matchAll [1, 2, 1, 3] as multiset integer with twin $n _ -> n
    ---> [1, 1]
@@ -289,13 +289,13 @@ A not-pattern ``!p`` matches with the object if the object does not match the pa
    ---> True
 
    -- Returns True if and only if the collection does not contain 1
-   f :=
+   def f :=
      \match as multiset integer with
       | !(#1 :: _) -> True
       | _          -> False
 
    -- Returns True if and only if the collection has an element other than 1
-   g :=
+   def g :=
      \match as multiset integer with
       | !#1 :: _ -> True
       | _        -> False
@@ -324,7 +324,7 @@ The variables bound in the ``let`` pattern can be used in the body of the ``let`
 
 ::
 
-   f x :=
+   def f x :=
      match x as multiset integer with
      | let n := length x in #n :: #n :: _ -> True
      | _                                  -> False
@@ -367,7 +367,7 @@ This ``unorderedIntegerPair`` matcher can be defined as follows.
 
 ::
 
-   unorderedIntegerPair :=
+   def unorderedIntegerPair :=
      matcher
        | pair $ $ as (integer, integer) with
          | ($x, $y) -> [(x, y), (y, x)]
@@ -390,7 +390,7 @@ For example, ``unorderedPair`` for an arbitrary matcher can be defined as follow
 
 ::
 
-   unorderedPair m :=
+   def unorderedPair m :=
      matcher
        | pair $ $ as (m, m) with
          | ($x, $y) -> [(x, y), (y, x)]
@@ -412,7 +412,7 @@ The first identifiers in each line of the ``algebraicDataMatcher`` (``var``, ``a
 
 ::
 
-   term :=
+   def term :=
      algebraicDataMatcher
        | var string       -- variable
        | abs string term  -- lambda abstraction
@@ -422,7 +422,7 @@ The above definition is desugared into the following one:
 
 ::
 
-   term :=
+   def term :=
      matcher
        | var $ as string with
          | Var $x -> [x]

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -38,7 +38,7 @@ Note that the statements (such as definitions and ``loadFile``) are not expressi
 ::
 
    $ cat name-of-file-to-test.egi
-   x := 1
+   def x := 1
    x + 2
    "This is the third line"
 
@@ -53,7 +53,7 @@ Command line arguments are given to the ``main`` function as a collection of str
 ::
 
    $ cat name-of-file-to-run.egi
-   main args :=
+   def main args :=
       print "Hello, world!"
 
    $ egison name-of-file-to-run.egi

--- a/docs/tutorial/io.rst
+++ b/docs/tutorial/io.rst
@@ -14,7 +14,7 @@ Let's start this tutorial by greeting the world. The following is the "Hello wor
 ::
 
    -- Save this code as a "hello.egi" file
-   main args :=
+   def main args :=
      write "Hello, World!\n"
 
 We can execute the above program as follows.
@@ -38,7 +38,7 @@ For instance, assume the following program.
 ::
 
    -- Save this code as a "args.egi" file
-   main args :=
+   def main args :=
      write (show args)
 
 If you execute the following commands, you will see that the arguments are given to ``main`` as ``args``.
@@ -60,7 +60,7 @@ If you know Haskell, you probably notice that it is the same with the ``do`` exp
 ::
 
    -- Save this code as a "repl.egi" file
-   repl := do
+   def repl := do
      write "input: "
      flush ()
      let input := readLine ()
@@ -68,7 +68,7 @@ If you know Haskell, you probably notice that it is the same with the ``do`` exp
      print ""
      repl
 
-   main args := repl
+   def main args := repl
 
 Then, execute it as follow.
 Note that ``write "input: "``, ``flush ()``, ``readLine ()`` and ``write input`` are executed in the order.
@@ -95,4 +95,4 @@ For example, the following is a definition of the ``pureRand`` function in ``lib
 
 ::
 
-   pureRand s e := io (rand s e)
+   def pureRand s e := io (rand s e)

--- a/docs/tutorial/quick-tour.rst
+++ b/docs/tutorial/quick-tour.rst
@@ -61,7 +61,7 @@ When there is only one match clause, we can omit the ``|`` before the match clau
 
    matchAll target as matcher with pattern -> body
 
-   
+
 The following is an example of pattern matching with multiple results.
 ``++`` is called **join pattern**, which splits a list into two segments.
 The ``matchAll`` evaluates the body for every possible matching result of the join pattern.
@@ -97,7 +97,7 @@ This ``matchAll`` extracts all twin primes from this infinite list of prime numb
 
 ::
 
-   twinPrimes := matchAll primes as list integer with
+   def twinPrimes := matchAll primes as list integer with
      | _ ++ $p :: #(p + 2) :: _ -> (p, p + 2)
 
    take 8 twinPrimes
@@ -111,7 +111,7 @@ A predicate pattern is prepended with ``?``, and a unary predicate follows after
 
 ::
 
-   twinPrimes := matchAll primes as list integer with
+   def twinPrimes := matchAll primes as list integer with
      | _ ++ $p :: ?(\q -> q = p + 2) :: _ -> (p, p + 2)
 
 
@@ -202,7 +202,7 @@ If we use ``matchAll``, the outcome will be the alternation of the elements in t
 
 ::
 
-   concat' xss := matchAll xss as list (list something) with
+   def concat' xss := matchAll xss as list (list something) with
      | _ ++ (_ ++ $x :: _) :: _ -> x
 
    concat' [[1,2,3],[4,5,6],[7,8,9]]
@@ -212,7 +212,7 @@ To fix this, we should use ``matchAllDFS`` instead.
 
 ::
 
-   concat xss := matchAllDFS xss as list (list something) with
+   def concat xss := matchAllDFS xss as list (list something) with
      | _ ++ (_ ++ $x :: _) :: _ -> x
 
    concat [[1,2,3],[4,5,6],[7,8,9]]
@@ -236,7 +236,7 @@ This usage of and-pattern is similar to the as-pattern in Haskell.
 
 ::
 
-   primeTriples := matchAll primes as list integer with
+   def primeTriples := matchAll primes as list integer with
      | _ ++ $p :: ((#(p + 2) | #(p + 4)) & $m) :: #(p + 6) :: _
      -> (p, m, p + 6)
 
@@ -267,7 +267,7 @@ It can be written using ``matchAll`` as follows.
 
 ::
 
-   comb2 xs := matchAll xs as list something with
+   def comb2 xs := matchAll xs as list something with
      | _ ++ $x_1 :: _ ++ $x_2 :: _ -> [x_1, x_2]
 
    comb2 [1,2,3,4] -- [[1,2],[1,3],[2,3],[1,4],[2,4],[3,4]]
@@ -283,7 +283,7 @@ Now, we generalize ``comb2``. The loop patterns can be used for this purpose.
 
 ::
 
-   comb n xs := matchAll xs as list something with
+   def comb n xs := matchAll xs as list something with
      | loop $i                 -- index variable
             (1, n)             -- index range
             (_ ++ $x_i :: ...) -- repeat pattern
@@ -366,7 +366,7 @@ Such combination of sequential patterns and not patterns is often useful when wr
 
 ::
 
-   singleCommonElem :=
+   def singleCommonElem :=
      match (xs, ys) as (multiset eq, multiset eq) with
        | [($x :: @, #x :: @),
          !($y :: _, #y :: _)] -> True
@@ -397,7 +397,7 @@ This is necessary for distinguishing variable patterns from nullary pattern cons
 
 ::
 
-   twin := \pat1 pat2 => (~pat1 & $x) :: #x :: ~pat2
+   def twin := \pat1 pat2 => (~pat1 & $x) :: #x :: ~pat2
 
    match [1, 1, 2, 3] as list integer with
    | twin $n $ns -> [n, ns]
@@ -421,7 +421,7 @@ For example, we can define the intersect function using a matcher for tuples of 
 
 ::
 
-   intersect xs ys := matchAll (xs,ys) as (multiset eq, multiset eq) with
+   def intersect xs ys := matchAll (xs,ys) as (multiset eq, multiset eq) with
      | ($x :: _, #x :: _) -> x
 
 ``eq`` is a user-defined matcher for data types for which equality is defined.
@@ -431,14 +431,14 @@ For example, we can define a matcher for a graph as a set of edges as follows, w
 
 ::
 
-   graph := multiset (integer, integer)
+   def graph := multiset (integer, integer)
 
 A matcher for adjacency graphs can also be defined.
 An adjacency graph is defined as a multiset of tuples of an integer and a multiset of integers.
 
 ::
 
-   adjacencyGraph := multiset (integer, multiset integer)
+   def adjacencyGraph := multiset (integer, multiset integer)
 
 Egison provides a handy syntactic sugar for defining a matcher for algebraic data types,
 while it can also be defined with ``matcher`` expressions.
@@ -446,7 +446,7 @@ For example, a matcher for binary trees can be defined using ``algebraicDataMatc
 
 ::
 
-   binaryTree a := algebraicDataMatcher
+   def binaryTree a := algebraicDataMatcher
      | bLeaf a
      | bNode a (binaryTree a) (binaryTree a)
 
@@ -457,6 +457,6 @@ For example, we can define a matcher for trees whose nodes have an arbitrary num
 
 ::
 
-   tree a := algebraicDataMatcher
+   def tree a := algebraicDataMatcher
      | leaf a
      | node a (multiset (tree a))


### PR DESCRIPTION
Changed the syntax to start definitions with `def` keyword from [v4.1.0](https://github.com/egison/egison/blob/master/Changelog.md#backward-incompatible-changes).
But, Document is not follow this changes.
ref: https://github.com/egison/egison/pull/255#discussion_r507390216

So, added `def` keyword to sample code in docs.

After:

```
$ git grep -n ' :=' docs | grep -v ' def '
docs/reference/basic-syntax.rst:155:   let x := 1 in x + 1 ---> 2
docs/reference/basic-syntax.rst:162:   let x := 1
docs/reference/basic-syntax.rst:163:       y := 2
docs/reference/basic-syntax.rst:172:   let { x := 1 ; y := 2 } in x + y
docs/reference/basic-syntax.rst:179:   let y := x  -- 'x' is defined in the next binding
docs/reference/basic-syntax.rst:180:       x := 1
docs/reference/basic-syntax.rst:185:   let isOdd n := if n = 0 then False else isEven (n - 1)
docs/reference/basic-syntax.rst:186:       isEven n := if n = 0 then True else isOdd (n - 1)
docs/reference/basic-syntax.rst:194:   x := 3
docs/reference/basic-syntax.rst:196:   let y := x
docs/reference/basic-syntax.rst:197:       x := 1
docs/reference/basic-syntax.rst:215:       x1 := expr1
docs/reference/basic-syntax.rst:216:       x2 := expr2
docs/reference/basic-syntax.rst:219:   let x1 := expr1
docs/reference/basic-syntax.rst:220:       x2 := expr2
docs/reference/basic-syntax.rst:249:     let line := readLine ()
docs/reference/basic-syntax.rst:285:         let z := fn init x
docs/reference/pattern-matching.rst:329:     | let n := length x in #n :: #n :: _ -> True
docs/reference/primitive-functions.rst:366:      let inport := openInputFile "file.txt"
docs/reference/primitive-functions.rst:373:      let outport := openOuputFile "file.txt"
docs/reference/primitive-functions.rst:386:      let c := readChar ()
docs/reference/primitive-functions.rst:392:      let line := readLine ()
docs/reference/primitive-functions.rst:410:      let c := readCharFromPort inport
docs/reference/primitive-functions.rst:416:      let line := readLineFromPort inport
docs/reference/primitive-functions.rst:434:      let b := isEof ()
docs/reference/primitive-functions.rst:446:      let b := isEofPort inport
docs/reference/primitive-functions.rst:458:      let lines := readFile "file.txt"
docs/tutorial/io.rst:66:     let input := readLine ()
```

`docs/reference/basic-syntax.rst:215-216` is local definition using `where`.
Otherwise, local definitions using `let`.


