### PR TITLE
Use test arguments for egison:test suite

### DIFF
--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,8 +1,9 @@
 module Main where
 
 import           Control.Monad.Trans.Class      (lift)
+import           System.Environment             (getArgs)
 
-import           Test.Framework                 (defaultMain)
+import           Test.Framework                 (defaultMainWithArgs)
 import           Test.Framework.Providers.HUnit (hUnitTestToTests)
 import           Test.HUnit
 
@@ -12,7 +13,8 @@ import           Language.Egison.MathOutput
 main :: IO ()
 main = do
   t <- evalRuntimeT defaultOption mathOutputTest
-  defaultMain . hUnitTestToTests . test $ t : map runTestCase testCases
+  args <- getArgs
+  flip defaultMainWithArgs args . hUnitTestToTests . test $ t : map runTestCase testCases
 
 testCases :: [FilePath]
 testCases =


### PR DESCRIPTION
`stack test` have `--test-arguments` option.
This is option that pass arguments to test suite.

for example

```
$ stack test egison:test --test-arguments=--help
...
Registering library for egison-4.1.1..
egison> test (suite: test, args: --help)
                    
Usage: test [OPTIONS]
                   --help                                       show this help message
  -j NUMBER        --threads=NUMBER                             number of threads to use to run tests
                   --test-seed=NUMBER|random                    default seed for test random number generator
  -a NUMBER        --maximum-generated-tests=NUMBER             how many automated tests something like QuickCheck should try, by default
                   --maximum-unsuitable-generated-tests=NUMBER  how many unsuitable candidate tests something like QuickCheck should endure before giving up, by default
  -s NUMBER        --maximum-test-size=NUMBER                   to what size something like QuickCheck should test the properties, by default
  -d NUMBER        --maximum-test-depth=NUMBER                  to what depth something like SmallCheck should test the properties, by default
  -o NUMBER        --timeout=NUMBER                             how many seconds a test should be run for before giving up, by default
                   --no-timeout                                 specifies that tests should be run without a timeout, by default
  -l               --list-tests                                 list available tests but don't run any; useful to guide subsequent --select-tests
  -t TEST-PATTERN  --select-tests=TEST-PATTERN                  only tests that match at least one glob pattern given by an instance of this argument will be run
                   --jxml=FILE                                  write a JUnit XML summary of the output to FILE
                   --jxml-nested                                use nested testsuites to represent groups in JUnit XML (not standards compliant)
                   --plain                                      do not use any ANSI terminal features to display the test run
                   --color                                      use ANSI terminal features to display the test run
                   --hide-successes                             hide sucessful tests, and only show failures


egison> Test suite test failed
Completed 2 action(s).
Test suite failure for package egison-4.1.1
    test:  exited with: ExitFailure 1
Logs printed to console
```

And can run specify test file using `--select-tests` of test-framework.

```
$ stack test egison:test --ta=--select-tests="test/syntax.egi"
egison> test (suite: test, args: --select-tests=test/syntax.egi)

io and do expression
io and do expression without newline
:test/syntax.egi: [OK]

         Test Cases  Total      
 Passed  1           1          
 Failed  0           0          
 Total   1           1          

egison> Test suite test passed
```

This feature is really useful, to implement new feature (e.g #260) or add missing test (e.g. #202).
