### PR TITLE
Add version bounds to dependent modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - case "$BUILD" in
       cabal)
         cabal update;
+        cabal install happy;
         cabal install --only-dependencies --enable-tests
         ;;
       stack)

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 script:
   - case "$BUILD" in
       cabal)
-        cabal test
+        cabal test test
         ;;
       stack)
         stack --no-terminal $ARGS --skip-ghc-check test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: haskell
 
 dist: xenial
 
+cabal: "2.4"
+
 # Caching so the next build will be fast too.
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,51 @@
-language: generic
+language: haskell
 
 dist: xenial
-
-os: linux
 
 # Caching so the next build will be fast too.
 cache:
   directories:
     - $HOME/.stack
+    - $HOME/.cabal/packages
+    - $HOME/.cabal/store
+
+matrix:
+  fast_finish: true
+  include:
+  - env: BUILD=cabal
+    ghc: 8.6.3
+  - env: BUILD=stack ARGS="--system-ghc"
+    ghc: 8.8.4
 
 before_install:
   # Download and unpack the stack executable
   - mkdir -p ~/.local/bin
-  - export PATH=$HOME/.local/bin:$PATH
-  - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - case "$BUILD" in
+      cabal)
+        export PATH="$HOME"/.cabal/bin:$PATH
+        ;;
+      stack)
+        export PATH=$HOME/.local/bin:$PATH
+        ;;
+
+install:
+  - case "$BUILD" in
+      cabal)
+        cabal update
+        ;;
+      stack)
+        mkdir -p ~/.local/bin;
+        travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+        ;;
 
 script:
-  # - stack init
-  - stack --no-terminal --skip-ghc-check test
+  - case "$BUILD" in
+      cabal)
+        cabal build
+        ;;
+      stack)
+        stack --no-terminal $ARGS --skip-ghc-check test
+        ;;
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ before_install:
 install:
   - case "$BUILD" in
       cabal)
-        cabal update
+        cabal update;
+        cabal install --only-dependencies --enable-tests
         ;;
       stack)
         mkdir -p ~/.local/bin;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
   include:
   - env: BUILD=cabal
     ghc: 8.6.3
+  - env: BUILD=cabal
+    ghc: 8.10.1
   - env: BUILD=stack ARGS="--system-ghc"
     ghc: 8.8.4
 
@@ -37,7 +39,6 @@ install:
         cabal install --only-dependencies --enable-tests
         ;;
       stack)
-        mkdir -p ~/.local/bin;
         travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
         ;;
     esac
@@ -45,7 +46,7 @@ install:
 script:
   - case "$BUILD" in
       cabal)
-        cabal build
+        cabal test
         ;;
       stack)
         stack --no-terminal $ARGS --skip-ghc-check test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
       stack)
         export PATH=$HOME/.local/bin:$PATH
         ;;
+    esac
 
 install:
   - case "$BUILD" in
@@ -37,6 +38,7 @@ install:
         mkdir -p ~/.local/bin;
         travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
         ;;
+    esac
 
 script:
   - case "$BUILD" in
@@ -46,6 +48,7 @@ script:
       stack)
         stack --no-terminal $ARGS --skip-ghc-check test
         ;;
+    esac
 
 branches:
   only:

--- a/egison.cabal
+++ b/egison.cabal
@@ -84,16 +84,15 @@ source-repository head
 Library
   default-language:    Haskell2010
   Build-Depends:
-      base >= 4.7 && < 5
-    , array
-    , random
-    , containers
-    , unordered-containers
-    , haskeline
+      base                 >= 4.7     && < 5
+    , random               == 1.*
+    , containers           == 0.6.*
+    , unordered-containers >= 0.1.0.0 && < 0.3
+    , haskeline            >= 0.7     && < 0.9
     , transformers
-    , mtl >=2.2.1
-    , parsec >= 3.0
-    , megaparsec >= 7.0.0
+    , mtl                  >= 2.2.1
+    , parsec               >= 3.0
+    , megaparsec           >= 7.0.0
     , parser-combinators
     , directory
     , ghc
@@ -107,7 +106,7 @@ Library
     , optparse-applicative
     , prettyprinter
     , unicode-show
-    , sweet-egison >= 0.1.1.3
+    , sweet-egison         >= 0.1.1.3
   if !impl(ghc > 8.0)
     Build-Depends: fail
   Hs-Source-Dirs:  hs-src
@@ -208,7 +207,6 @@ Executable egison
   Build-depends:
       egison
     , base >= 4.0 && < 5
-    , array
     , containers
     , exceptions
     , unordered-containers

--- a/egison.cabal
+++ b/egison.cabal
@@ -84,7 +84,7 @@ source-repository head
 Library
   default-language:    Haskell2010
   Build-Depends:
-      base                 >= 4.7     && < 5
+      base                 >= 4.8     && < 5
     , random               == 1.*
     , containers           == 0.6.*
     , unordered-containers >= 0.1.0.0 && < 0.3
@@ -96,7 +96,7 @@ Library
     , parser-combinators   >= 1.0     && < 2.0
     , directory            >= 1.3.0
     , text                 >= 0.2     && < 1.3
-    , regex-tdfa
+    , regex-tdfa           >= 1.2.0
     , process              >= 1.0     && < 2.0
     , vector               == 0.12.*
     , hashable             >= 1.0     && < 2.0
@@ -156,7 +156,7 @@ Test-Suite test
   Main-Is:        Test.hs
   Build-Depends:
       egison
-    , base >= 4.0 && < 5
+    , base >= 4.8 && < 5
     , transformers
     , mtl
     , Glob
@@ -175,7 +175,7 @@ Test-Suite test-cli
   Main-Is:        OptionsTest.hs
   Build-Depends:
       egison
-    , base >= 4.0 && < 5
+    , base >= 4.8 && < 5
     , process
     , HUnit
     , test-framework
@@ -191,7 +191,7 @@ Benchmark benchmark
   Main-Is: Benchmark.hs
   Build-Depends:
       egison
-    , base >= 4.0 && < 5
+    , base >= 4.8 && < 5
     , criterion >= 0.5
     , transformers
   Other-modules:   Paths_egison
@@ -224,7 +224,7 @@ Executable egison-translate
   Main-is:          translator.hs
   Build-depends:
       egison
-    , base >= 4.0 && < 5
+    , base >= 4.8 && < 5
     , prettyprinter
   Hs-Source-Dirs:   hs-src/Tool
   ghc-options:  -Wall -Wno-name-shadowing

--- a/egison.cabal
+++ b/egison.cabal
@@ -99,7 +99,6 @@ Library
     , regex-tdfa
     , process              >= 1.0     && < 2.0
     , vector               == 0.12.*
-    , split
     , hashable             >= 1.0     && < 2.0
     , optparse-applicative >= 0.14    && < 0.20
     , prettyprinter        >= 1.0     && < 2.0
@@ -227,6 +226,5 @@ Executable egison-translate
       egison
     , base >= 4.0 && < 5
     , prettyprinter
-    , split
   Hs-Source-Dirs:   hs-src/Tool
   ghc-options:  -Wall -Wno-name-shadowing

--- a/egison.cabal
+++ b/egison.cabal
@@ -89,22 +89,22 @@ Library
     , containers           == 0.6.*
     , unordered-containers >= 0.1.0.0 && < 0.3
     , haskeline            >= 0.7     && < 0.9
-    , transformers
-    , mtl                  >= 2.2.1
+    , transformers         >= 0.4     && < 0.6
+    , mtl                  >= 2.2.2   && < 3.0
     , parsec               >= 3.0
-    , megaparsec           >= 7.0.0
-    , parser-combinators
-    , directory
-    , text
+    , megaparsec           >= 7.0.0   && < 12.0
+    , parser-combinators   >= 1.0     && < 2.0
+    , directory            >= 1.3.0
+    , text                 >= 0.2     && < 1.3
     , regex-tdfa
-    , process
-    , vector
+    , process              >= 1.0     && < 2.0
+    , vector               == 0.12.*
     , split
-    , hashable
-    , optparse-applicative
-    , prettyprinter
-    , unicode-show
-    , sweet-egison         >= 0.1.1.3
+    , hashable             >= 1.0     && < 2.0
+    , optparse-applicative >= 0.14    && < 0.20
+    , prettyprinter        >= 1.0     && < 2.0
+    , unicode-show         == 0.1.*
+    , sweet-egison         == 0.1.1.3
   if !impl(ghc > 8.0)
     Build-Depends: fail
   Hs-Source-Dirs:  hs-src

--- a/egison.cabal
+++ b/egison.cabal
@@ -95,8 +95,6 @@ Library
     , megaparsec           >= 7.0.0
     , parser-combinators
     , directory
-    , ghc
-    , ghc-paths
     , text
     , regex-tdfa
     , process
@@ -207,21 +205,13 @@ Executable egison
   Build-depends:
       egison
     , base >= 4.0 && < 5
-    , containers
     , exceptions
-    , unordered-containers
     , haskeline
-    , transformers
     , mtl
-    , parsec >= 3.1
     , directory
-    , ghc
-    , ghc-paths
     , filepath
     , text
-    , process
     , regex-tdfa
-    , vector
     , optparse-applicative
   if !impl(ghc > 8.0)
     Build-Depends: semigroups

--- a/hs-src/Language/Egison/Parser/SExpr.hs
+++ b/hs-src/Language/Egison/Parser/SExpr.hs
@@ -24,7 +24,6 @@ import           Control.Monad.Identity (Identity)
 import           Data.Char              (isLower, isUpper, toUpper)
 import           Data.Either
 import           Data.Functor           (($>))
-import           Data.List.Split        (splitOn)
 import           Data.Ratio
 import qualified Data.Set               as Set
 import qualified Data.Text              as T
@@ -858,8 +857,17 @@ renamedFunctions =
   , ("rdc",         "init")
   ]
 
+splitOn :: Eq a => a -> [a] -> [[a]]
+splitOn sep list =
+  case span (/= sep) list of
+    ([], [])    -> []
+    ([], _ : t) -> splitOn sep t
+    (h, [])     -> [h]
+    (h, _ : t)  -> h : splitOn sep t
+
 -- Translate identifiers for Non-S syntax
 toCamelCase :: String -> String
+toCamelCase "-" = "-"
 toCamelCase "-'" = "-'"
 toCamelCase "f.-'" = "f.-'"
 toCamelCase "b.." = "b."
@@ -869,7 +877,7 @@ toCamelCase (flip lookup renamedFunctions -> Just name') =
 toCamelCase (reverse -> 'm':'/':xs) =
   toCamelCase (reverse xs ++ "-as")
 toCamelCase x =
-  let heads:tails = splitOn "-" x
+  let heads:tails = splitOn '-' x
    in concat $ heads : map capitalize tails
   where
     capitalize []     = "-"


### PR DESCRIPTION
* Add version bounds to dependencies listed in `egison.cabal` to respect [PVP](https://pvp.haskell.org/).
* Remove unused packages from egison.cabal
* Test multiple versions of GHC on CI.