### PR TITLE
Add anonymous list&tuple parameter functions

### DIFF
--- a/hs-src/Language/Egison/AST.hs
+++ b/hs-src/Language/Egison/AST.hs
@@ -106,6 +106,8 @@ data Expr
   | ApplyExpr Expr [Expr]
   | CApplyExpr Expr Expr
   | AnonParamFuncExpr Integer Expr
+  | AnonTupleParamFuncExpr Integer Expr
+  | AnonListParamFuncExpr Integer Expr
   | AnonParamExpr Integer
 
   | GenerateTensorExpr Expr Expr

--- a/hs-src/Language/Egison/AST.hs
+++ b/hs-src/Language/Egison/AST.hs
@@ -136,8 +136,8 @@ data ArgPattern
   | APInductivePat String [Arg ArgPattern]
   | APTuplePat [Arg ArgPattern]
   | APEmptyPat
-  | APConsPat (Arg ArgPattern) (Arg ArgPattern)
-  | APSnocPat (Arg ArgPattern) (Arg ArgPattern)
+  | APConsPat (Arg ArgPattern) ArgPattern
+  | APSnocPat ArgPattern (Arg ArgPattern)
   deriving Show
 
 data VarIndex

--- a/hs-src/Language/Egison/Desugar.hs
+++ b/hs-src/Language/Egison/Desugar.hs
@@ -227,13 +227,13 @@ desugar (LambdaExpr args expr) = do
       tmp1 <- fresh
       tmp2 <- fresh
       return (tmp, LetExpr [Bind (PDConsPat (PDPatVar tmp1) (PDPatVar tmp2)) (VarExpr tmp)]
-                     (ApplyExpr (LambdaExpr [arg1, arg2] expr) [VarExpr tmp1, VarExpr tmp2]))
+                     (ApplyExpr (LambdaExpr [arg1, TensorArg arg2] expr) [VarExpr tmp1, VarExpr tmp2]))
     desugarArgPat (APSnocPat arg1 arg2) expr = do
       tmp  <- fresh
       tmp1 <- fresh
       tmp2 <- fresh
       return (tmp, LetExpr [Bind (PDSnocPat (PDPatVar tmp1) (PDPatVar tmp2)) (VarExpr tmp)]
-                     (ApplyExpr (LambdaExpr [arg1, arg2] expr) [VarExpr tmp1, VarExpr tmp2]))
+                     (ApplyExpr (LambdaExpr [TensorArg arg1, arg2] expr) [VarExpr tmp1, VarExpr tmp2]))
 
 desugar (LambdaExpr' names expr) = do
   let (args', expr') = foldr desugarInvertedArgs ([], expr) names
@@ -376,10 +376,9 @@ desugar (AnonTupleParamFuncExpr n expr) = do
   return $ ILetRecExpr [(PDPatVar (stringToVar "%0"), lambda)] (IVarExpr "%0")
 
 desugar (AnonListParamFuncExpr n expr) = do
-  let args = map (\n -> '%' : show n) [1..n]
-  -- TODO: Pattern match against list
-  lambda <- desugar $
-    LambdaExpr [TensorArg (APTuplePat $ map (TensorArg . APPatVar) args)] expr
+  let args' = map (\n -> TensorArg (APPatVar ('%' : show n))) [1..n]
+  let args = foldr APConsPat APEmptyPat args'
+  lambda <- desugar $ LambdaExpr [TensorArg args] expr
   return $ ILetRecExpr [(PDPatVar (stringToVar "%0"), lambda)] (IVarExpr "%0")
 
 desugar (QuoteExpr expr) =

--- a/hs-src/Language/Egison/Desugar.hs
+++ b/hs-src/Language/Egison/Desugar.hs
@@ -366,6 +366,22 @@ desugar (AnonParamFuncExpr n expr) = do
   let lambda = ILambdaExpr Nothing (map (\n -> '%' : show n) [1..n]) expr'
   return $ ILetRecExpr [(PDPatVar (stringToVar "%0"), lambda)] (IVarExpr "%0")
 
+desugar (AnonTupleParamFuncExpr 1 expr) = do
+  lambda <- desugar $ LambdaExpr' [TensorArg "%1"] expr
+  return $ ILetRecExpr [(PDPatVar (stringToVar "%0"), lambda)] (IVarExpr "%0")
+desugar (AnonTupleParamFuncExpr n expr) = do
+  let args = map (\n -> '%' : show n) [1..n]
+  lambda <- desugar $
+    LambdaExpr [TensorArg (APTuplePat $ map (TensorArg . APPatVar) args)] expr
+  return $ ILetRecExpr [(PDPatVar (stringToVar "%0"), lambda)] (IVarExpr "%0")
+
+desugar (AnonListParamFuncExpr n expr) = do
+  let args = map (\n -> '%' : show n) [1..n]
+  -- TODO: Pattern match against list
+  lambda <- desugar $
+    LambdaExpr [TensorArg (APTuplePat $ map (TensorArg . APPatVar) args)] expr
+  return $ ILetRecExpr [(PDPatVar (stringToVar "%0"), lambda)] (IVarExpr "%0")
+
 desugar (QuoteExpr expr) =
   IQuoteExpr <$> desugar expr
 

--- a/hs-src/Language/Egison/Parser/NonS.hs
+++ b/hs-src/Language/Egison/Parser/NonS.hs
@@ -469,7 +469,9 @@ atomExpr = do
 
 -- Atomic expressions without index
 atomExpr' :: Parser Expr
-atomExpr' = anonParamFuncExpr    -- must come before |constantExpr|
+atomExpr' = anonParamFuncExpr      -- must come before |constantExpr|
+        <|> anonTupleParamFuncExpr -- must come before |tupleOrParenExpr|
+        <|> anonListParamFuncExpr  -- must come before |collectionExpr|
         <|> ConstantExpr <$> constantExpr
         <|> FreshVarExpr <$ symbol "#"
         <|> VarExpr <$> ident
@@ -487,6 +489,16 @@ anonParamFuncExpr = do
   n    <- try (L.decimal <* char '#') -- No space after the index
   body <- atomExpr                    -- No space after '#'
   return $ AnonParamFuncExpr n body
+
+anonTupleParamFuncExpr :: Parser Expr
+anonTupleParamFuncExpr = do
+  n <- try (char '(' *> L.decimal <* string ")#")
+  AnonTupleParamFuncExpr n <$> atomExpr
+
+anonListParamFuncExpr :: Parser Expr
+anonListParamFuncExpr = do
+  n <- try (char '[' *> L.decimal <* string "]#")
+  AnonListParamFuncExpr n <$> atomExpr
 
 constantExpr :: Parser ConstantExpr
 constantExpr = numericExpr

--- a/test/syntax.egi
+++ b/test/syntax.egi
@@ -607,6 +607,9 @@ assertEqual "anonymous parameter recursive function"
   [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
 
 assertEqual "anonymous tuple parameter function"
+  ((0)#10 ())
+  10
+assertEqual "anonymous tuple parameter function"
   ((1)#(%1 + %1) 10)
   20
 assertEqual "anonymous tuple parameter function"

--- a/test/syntax.egi
+++ b/test/syntax.egi
@@ -612,6 +612,13 @@ assertEqual "anonymous tuple parameter function"
 assertEqual "anonymous tuple parameter function"
   ((2)#(%1 + %2) (10, 20))
   30
+assertEqual "anonymous list parameter function"
+  ([0]#10 [])
+  10
+assertEqual "anonymous list parameter function"
+  ([2]#(%1 + %2) [10, 20])
+  30
+
 
 def f *$x *$y := x + y
 

--- a/test/syntax.egi
+++ b/test/syntax.egi
@@ -595,16 +595,23 @@ assertEqual "char hash access"
   13
 
 --
--- Partial Application
+-- Anonymous parameter function
 --
 
-assertEqual "partial application '#'"
+assertEqual "anonymous parameter function"
   (2#(10 * %1 + %2) 1 2)
   12
 
-assertEqual "recursive partial application '#'"
+assertEqual "anonymous parameter recursive function"
   (take 10 (1#(%1 :: (%0 (%1 * 2))) 2))
   [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+
+assertEqual "anonymous tuple parameter function"
+  ((1)#(%1 + %1) 10)
+  20
+assertEqual "anonymous tuple parameter function"
+  ((2)#(%1 + %2) (10, 20))
+  30
 
 def f *$x *$y := x + y
 


### PR DESCRIPTION
* Add anonymous list parameter functions: `[2]#(%1 + %2)` is a syntax sugar for `\[x, y] -> x + y`
* Add anonymous tuple parameter functions: `(2)#(%1 + %2)` is a syntax sugar for `\(x, y) -> x + y`